### PR TITLE
Typos and typography

### DIFF
--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -15,7 +15,7 @@ definition of a tensor. A good starting point is the following:
 
     ``t ∈ V_1 ⊗ V_2 ⊗ … ⊗ V_N.``
 
-If you think of a tensor as an object with indices, a rank `N` tensor has `N` indices where
+If you think of a tensor as an object with indices, a rank ``N`` tensor has ``N`` indices where
 every index is associated with the corresponding vector space in that it labels a particular
 basis in that space. We will return to index notation at the very end of this manual.
 
@@ -51,7 +51,7 @@ reorganise which vector spaces appear in the domain and the codomain of the tens
 in which order. This amounts to defining canonical isomorphisms between the different ways
 to order and partition the tensor indices (i.e. the vector spaces). For example, a linear
 map ``W → V`` is often denoted as a rank 2 tensor in ``V ⊗ W^*``, where ``W^*`` corresponds
-to the dual space of `W`. This simple example introduces two new concepts.
+to the dual space of ``W``. This simple example introduces two new concepts.
 
 1.  Typical vector spaces can appear in the domain and codomain in different variants, e.g.
     as normal space or dual space. In fact, the most generic case is that every vector
@@ -81,7 +81,7 @@ to the dual space of `W`. This simple example introduces two new concepts.
 
     Finally, in ``ℝ^d`` with a Euclidean inner product, these four different spaces are
     equivalent and we only need one type of index. The space is completely characterized by
-    its dimension `d`. This is the setting of much of classical mechanics and we refer to
+    its dimension ``d``. This is the setting of much of classical mechanics and we refer to
     such tensors as cartesian tensors and the corresponding space as cartesian space. These
     are the tensors that can equally well be represented as multidimensional arrays (i.e.
     using some `AbstractArray{<:Real,N}` in Julia) without loss of structure.
@@ -106,9 +106,9 @@ This brings us to our final (yet formal) definition
 
 Physical problems often have some symmetry, i.e. the setup is invariant under the action of
 a group ``\mathsf{G}`` which acts on the vector spaces ``V`` in the problem according to a
-certain representation. Having quantum mechanics in mind, TensorKit.jl restricts so far to
+certain representation. Having quantum mechanics in mind, TensorKit.jl is so far restricted to
 unitary representations. A general representation space ``V`` can be specified as the
-number of times every irreducible representation (irrep) `a` of ``\mathsf{G}`` appears, i.e.
+number of times every irreducible representation (irrep) ``a`` of ``\mathsf{G}`` appears, i.e.
 
 ``V = \bigoplus_{a} ℂ^{n_a} ⊗ R_a``
 
@@ -123,7 +123,7 @@ representation
 with ``𝟙_{n_a}`` the ``n_a × n_a`` identity matrix. The total dimension of ``V`` is given
 by ``∑_a n_a d_a``.
 
-The reason of implementing symmetries is to exploit the compuation and memory gains
+The reason of implementing symmetries is to exploit the computation and memory gains
 resulting from restricting to tensor maps ``t:W_1 ⊗ W_2 ⊗ … ⊗ W_{N_2} → V_1 ⊗ V_2 ⊗ … ⊗
 V_{N_1}`` that are invariant under the symmetry (i.e. that act as
 [intertwiners](https://en.wikipedia.org/wiki/Equivariant_map#Representation_theory)
@@ -131,15 +131,15 @@ between the symmetry action on the domain and the codomain). Indeed, such tensor
 block diagonal because of [Schur's lemma](https://en.wikipedia.org/wiki/Schur%27s_lemma),
 but only after we couple the individual irreps in the spaces ``W_i`` to a joint irrep,
 which is then again split into the individual irreps of the spaces ``V_i``. The basis
-change from the tensor product of irreps in the (co)domain to the joint irrep isimplemented
-by a sequence of Clebsch-Gordan coefficients, also known as a fusion (or splitting) tree.
+change from the tensor product of irreps in the (co)domain to the joint irrep is implemented
+by a sequence of Clebsch–Gordan coefficients, also known as a fusion (or splitting) tree.
 We implement the necessary machinery to manipulate these fusion trees under index
 permutations and repartitions for arbitrary groups ``\mathsf{G}``. In particular, this fits
-with the formalism of monoidal categories, and more specifically fusion categoreis,
+with the formalism of monoidal categories, and more specifically fusion categories,
 discussed below and only requires the *topological* data of the group, i.e. the fusion
 rules of the irreps, their quantum dimensions and the F-symbol (6j-symbol or more precisely
 Racah's W-symbol in the case of ``\mathsf{SU}_2``). In particular, we do not need the
-Clebsch-Gordan coefficients.
+Clebsch–Gordan coefficients.
 
 Further details are provided in [Sectors, representation spaces and fusion trees](@ref).
 
@@ -156,7 +156,7 @@ information. Furthermore, we recommend the nice introduction of [Beer et al.](^b
 To start, a category ``C`` consists of
 *   a class ``|C|`` of objects ``V``, ``W``, …
 *   for each pair of objects ``V`` and ``W``, a set ``hom(W,V)`` of morphisms ``f:W→V``;
-    for a given map `f`, `W` is called the *domain* or *source*, and `V` the *codomain* or
+    for a given map ``f``, ``W`` is called the *domain* or *source*, and ``V`` the *codomain* or
     *target*.
 *   an composition of morphisms ``f:W→V`` and ``g:X→W`` into ``(f ∘ g):X→V`` that is
     associative, such that for ``h:Y→X`` we have ``f ∘ (g ∘ h) = (f ∘ g) ∘ h``
@@ -264,7 +264,7 @@ It does makes sense to define or identify
 In fact, the above exact pairings are known as the left unit and co-unit, and ``V^*`` is the
 left dual of ``V``. There is also a notion of a right dual ``^*V`` and associated pairings,
 the right unit ``η'_V: I → ^*V ⊗ V`` and the right co-unit ``ϵ'_V: V ⊗ *^V → I``. An
-autonomous category `\mathbf{C}` is one where every object `V` has both a left and right
+autonomous category ``\mathbf{C}`` is one where every object ``V`` has both a left and right
 dual, and in this case they can be proven to be isomorphic. We will never distinguish
 between the two and refer simply to `dual(V)` for the dual of a vector space.
 

--- a/docs/src/man/sectors.md
+++ b/docs/src/man/sectors.md
@@ -17,7 +17,7 @@ The corresponding vector spaces will be canonically represented as
 ``V = ⨁_a ℂ^{n_a} ⊗ R_{a}``, where ``a`` labels the different irreps, ``n_a`` is the number
 of times irrep ``a`` appears and ``R_a`` is the vector space associated with irrep ``a``.
 Irreps are also known as spin sectors (in the case of ``\mathsf{SU}_2``) or charge sectors
-(in the case of `\mathsf{U}_1`), and we henceforth refer to `a` as a sector. As is briefly
+(in the case of ``\mathsf{U}_1``), and we henceforth refer to ``a`` as a sector. As is briefly
 discussed below, the approach we follow does in fact go beyond the case of irreps of groups,
 and sectors would more generally correspond to simple objects in a (ribbon) fusion
 category. Nonetheless, every step can be appreciated by using the representation theory of
@@ -33,7 +33,7 @@ blocks. We refer to the latter as block sectors. The transformation from the unc
 sectors in the domain (or codomain) of the tensor map to the block sector is encoded in a
 fusion tree (or splitting tree). Essentially, it is a sequential application of pairwise
 fusion as described by the group's
-[Clebsch-Gordan (CG) coefficients](https://en.wikipedia.org/wiki/Clebsch–Gordan_coefficients).
+[Clebsch–Gordan (CG) coefficients](https://en.wikipedia.org/wiki/Clebsch–Gordan_coefficients).
 However, it turns out that we do not need the actual CG coefficients, but only how they
 transform under transformations such as interchanging the order of the incoming irreps or
 interchanging incoming and outgoing irreps. This information is known as the topological
@@ -43,7 +43,7 @@ it's actually [Racah's W-coefficients](https://en.wikipedia.org/wiki/Racah_W-coe
 in the case of ``\mathsf{SU}_2``.
 
 Below, we describe how to specify a certain type of sector what information about them
-needs to be implemented. Then, we describe how to build a space `V` composed of a direct sum
+needs to be implemented. Then, we describe how to build a space ``V`` composed of a direct sum
 of different sectors. In the last section, we explain the details of fusion trees, i.e.
 their construction and manipulation. But first, we provide a quick theoretical overview of
 the required data of the representation theory of a group.
@@ -96,7 +96,7 @@ If, for every ``a`` and ``b``, there is a unique ``c`` such that ``a ⊗ b = c``
 Indeed, the representations of a group have this property if and only if the group
 multiplication law is commutative. In that case, all spaces ``R_{a}`` associated with the
 representation are one-dimensional and thus trivial. In all other cases, the category is
-nonabelian. We find it useful to further finegrain between categories which have all
+non-abelian. We find it useful to further distinguish between categories which have all
 ``N_{a,b}^c`` equal to zero or one (such that no multiplicity labels are needed), e.g. the
 representations of ``\mathsf{SU}_2``, and those where some ``N_{a,b}^c`` are larger than
 one, e.g. the representations of ``\mathsf{SU}_3``.
@@ -123,7 +123,7 @@ The minimal data to completely specify a type of sector are
 *   the identity object `u`, such that ``a ⊗ u = a = u ⊗ a``; this is implemented by the
     function `one(a)` (and also in type domain) from Julia Base
 *   the dual or conjugate representation ``\overline{a}`` for which
-    `N_{a,\overline{a}}^{u} = 1`; this is implemented by `conj(a)` from Julia Base;
+    ``N_{a,\overline{a}}^{u} = 1``; this is implemented by `conj(a)` from Julia Base;
     `dual(a)` also works as alias, but `conj(a)` is the method that should be defined
 *   the F-symbol or recoupling coefficients ``[F^{a,b,c}_{d}]^e_f``, implemented as the
     function [`Fsymbol(a,b,c,d,e,f)`](@ref)
@@ -186,7 +186,7 @@ transformation:
 
 *   [Braiding](@ref) or permuting as defined by ``σ_{a,b}: R_a ⊗ R_b → R_b ⊗ R_a``:
 
-    ``σ_{a,b} ∘ X_{a,b}^{c,μ} = ∑_{ν} [R_{a,b}^c]^μ_ν X_{b,a}^{c,ν}
+    ``σ_{a,b} ∘ X_{a,b}^{c,μ} = ∑_{ν} [R_{a,b}^c]^μ_ν X_{b,a}^{c,ν}``
 
 Furthermore, there is a relation between splitting vertices and fusion vertices given by the
 B-symbol, but we refer to the section on [Fusion trees](@ref) for the precise definition and
@@ -353,7 +353,7 @@ A final non-abelian representation theory is that of the semidirect product
 systems with particle hole symmetry and the non-trivial element of ``ℤ_2`` acts as charge
 conjugation `C`. It has the effect of interchaning ``\mathsf{U}_1`` irreps ``n`` and
 ``-n``, and turns them together in a joint 2-dimensional index, except for the case
-``n=0``. Irreps are therefore labeled by integers `n ≧ 0`, however for `n=0` the ``ℤ₂``
+``n=0``. Irreps are therefore labeled by integers ``n ≧ 0``, however for ``n=0`` the ``ℤ₂``
 symmetry can be realized trivially or non-trivially, resulting in an even and odd one-
 dimensional irrep with ``\mathsf{U})_1`` charge ``0``. Given
 ``\mathsf{U}_1 ≂ \mathsf{SO}_2``, this group is also simply known as ``\mathsf{O}_2``, and
@@ -486,7 +486,7 @@ called ribbon fusion category. However, the category does not need to be modular
 category of representations of a finite group[^1] corresponds to a typical example (which is
 not modular and which have a symmetric braiding). Other examples are the representation of
 quasi-triangular Hopf algebras, which are typically known as anyon theories in the physics
-literature, e.g. Fibonicci anyons, Ising anyons, … In those cases, quantum dimensions
+literature, e.g. Fibonacci anyons, Ising anyons, … In those cases, quantum dimensions
 ``d_a`` are non-integer, and there is no vector space interpretation to objects ``R_a``
 (which we can identify with just ``a``) in the decomposition ``V = ⨁_a ℂ^{n_a} ⊗ R_{a}``.
 The different sectors ``a``, … just represent abstract objects. However, there is still a
@@ -673,7 +673,7 @@ such that ``(X_{a,b}^{c,μ})^† X_{a,b}^{c,μ} = \mathrm{id}_{R_c}`` and
 ``\sum_{c} \sum_{μ = 1}^{N_{a,b}^c} X_{a,b}^{c,μ} (X_{a,b}^{c,μ})^\dagger = \mathrm{id}_{R_a ⊗ R_b}``
 
 The tensors ``X_{a,b}^{c,μ}`` are the splitting tensors, their hermitian conjugate are the
-fusion tensors. For ``\mathsf{SU}_2``, their entries are given by the Clebsch-Gordan
+fusion tensors. For ``\mathsf{SU}_2``, their entries are given by the Clebsch–Gordan
 coefficients
 
 ### Canonical representation

--- a/docs/src/man/spaces.md
+++ b/docs/src/man/spaces.md
@@ -44,7 +44,7 @@ const ℂ = ComplexNumbers()
 ```
 Note that `ℝ` and `ℂ` can be typed as `\bbR`+TAB and `\bbC`+TAB. One reason for defining
 this new type hierarchy instead of recycling the types from Julia's `Number` hierarchy is
-to introduce some syntactic suggar without commiting type piracy. In particular, we now have
+to introduce some syntactic sugar without committing type piracy. In particular, we now have
 ```@repl tensorkit
 3 ∈ ℝ
 5.0 ∈ ℂ
@@ -54,7 +54,7 @@ ComplexF64 ⊆ ℂ
 ℝ ⊆ ℂ
 ℂ ⊆ ℝ
 ```
-and furthermore ––probably more usefully–– `ℝ^n` and `ℂ^n` create specific elementary vector
+and furthermore—probably more usefully—`ℝ^n` and `ℂ^n` create specific elementary vector
 spaces as described in the next section. The underlying field of a vector space or tensor
 `a` can be obtained with `field(a)`.
 


### PR DESCRIPTION
I fixed some typos and typography, while reading the manual. Please check that I did not mess something up. In particular, in `sectors.md`, I was not sure if it should be ``\mathsf{U}_1`` or ``\mathsf{SU}_1``.