### PR TITLE
Switch math engine back to MathJaX

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,8 @@ using TensorKit
 makedocs(modules=[TensorKit],
             sitename="TensorKit.jl",
             authors = "Jutho Haegeman",
-            format = Documenter.HTML(; prettyurls = get(ENV, "CI", nothing) == "true"),
+            format = Documenter.HTML(; prettyurls = get(ENV, "CI", nothing) == "true",
+                                     mathengine = Documenter.MathJax()),
             pages = [
                 "Home" => "index.md",
                 "Manual" => ["man/intro.md", "man/spaces.md", "man/sectors.md", "man/tensors.md"],


### PR DESCRIPTION
Since the latest version of Documenter.jl switched the default math engine from MathJaX to KaTeX, which is more light-weight but not as feature-complete, all equations set with Unicode are garbled:

<img width="842" alt="image" src="https://user-images.githubusercontent.com/117947/71484467-d9fa4e80-280c-11ea-98f1-a648acfda3c5.png">

This PR manually sets the math engine back to MathJaX, the alternative to change all Unicode to `\mathbb{1}` &c seemed less interesting.

Merry Christmas!