### PR TITLE
Fix a bug with svd of AdjointTensorMap

### DIFF
--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -221,7 +221,8 @@ function rightnull!(t::AdjointTensorMap{S}; alg::OrthogonalFactorizationAlgorith
     return adjoint(leftnull!(adjoint(t); alg = alg'))
 end
 function LinearAlgebra.svd!(t::AdjointTensorMap{S}; trunc::TruncationScheme = NoTruncation(), p::Real = 2, alg::Union{SVD,SDD} = SDD()) where {S<:EuclideanSpace}
-    return map(adjoint, reverse(svd!(adjoint(t); trunc = trunc, p = p, alg = alg)))
+    u, s, vt, err = svd!(adjoint(t); trunc = trunc, p = p, alg = alg)
+    return map(adjoint, (vt, s, u, err))
 end
 
 function leftorth!(t::TensorMap{S}; alg::OrthogonalFactorizationAlgorithm = QRpos()) where {S<:EuclideanSpace}


### PR DESCRIPTION
In the current master, observe the following:
```
julia> using TensorKit
julia> t = TensorMap(randn, Float64, ℂ^2 ← ℂ^2)'
AdjointTensorMap(ProductSpace(ℂ^2) ← ProductSpace(ℂ^2)):
 -0.44957311339859585  0.574946008374467 
 -1.0585667067396305   0.8048926380999573
julia> svd(t, (1,), (2,))
(0.0, AdjointTensorMap(ProductSpace(ℂ^2) ← ProductSpace(ℂ^2)):
 0.47443890076071277   0.8802884353693206 
 0.8802884353693206   -0.47443890076071277
, AdjointTensorMap(ProductSpace(ℂ^2) ← ProductSpace(ℂ^2)):
 1.508085327421287  0.0                
 0.0                0.16362510057556934
, AdjointTensorMap(ProductSpace(ℂ^2) ← ProductSpace(ℂ^2)):
 -0.7593330317060951  0.650702195293692
  0.650702195293692   0.759333031706095
)
```

The truncation error has been moved to being the first return value. Fixing this is of course a breaking change, but I really hope noone has code that does things like `err, U, S, Vt = svd(t', indsout, indsin)`.

By the way, this only comes up when specifying the index lists. Just calling `svd(t)` incurs a `copy(t)`, which removes the adjoint structure, and thus
```
julia> svd(t)
(TensorMap(ProductSpace(ℂ^2) ← ProductSpace(ℂ^2)):
 -0.47443890076071293  -0.8802884353693207 
 -0.8802884353693206    0.47443890076071293
, TensorMap(ProductSpace(ℂ^2) ← ProductSpace(ℂ^2)):
 1.5080853274212869  0.0                
 0.0                 0.16362510057556925
, TensorMap(ProductSpace(ℂ^2) ← ProductSpace(ℂ^2)):
  0.7593330317060952  -0.6507021952936921
 -0.6507021952936921  -0.7593330317060952
, 0.0)
```

I also included a test that catches this, by trying all the decomposition tests also on `AdjointTensorMap`s.