### PR TITLE
Add Dict and Pair constructors for Cartesian and Complex spaces

### DIFF
--- a/src/spaces/cartesianspace.jl
+++ b/src/spaces/cartesianspace.jl
@@ -9,6 +9,15 @@ struct CartesianSpace <: EuclideanSpace{ℝ}
     d::Int
 end
 CartesianSpace(d::Integer = 0; dual = false) = CartesianSpace(Int(d))
+function CartesianSpace(dim::Pair; dual = false)
+    if dim.first === Trivial()
+        return CartesianSpace(dim.second; dual = dual)
+    else
+        msg = "$(dim) is not a valid dimension for CartesianSpace"
+        throw(ArgumentError(msg))
+    end
+end
+CartesianSpace(dim::AbstractDict; dual = false) = CartesianSpace(dim...; dual = dual)
 
 Base.getindex(::RealNumbers) = CartesianSpace
 Base.getindex(::RealNumbers, d::Int) = CartesianSpace(d)

--- a/src/spaces/complexspace.jl
+++ b/src/spaces/complexspace.jl
@@ -10,6 +10,15 @@ struct ComplexSpace <: EuclideanSpace{ℂ}
   dual::Bool
 end
 ComplexSpace(d::Integer = 0; dual = false) = ComplexSpace(Int(d), dual)
+function ComplexSpace(dim::Pair; dual = false)
+    if dim.first === Trivial()
+        return ComplexSpace(dim.second; dual = dual)
+    else
+        msg = "$(dim) is not a valid dimension for ComplexSpace"
+        throw(ArgumentError(msg))
+    end
+end
+ComplexSpace(dims::AbstractDict; dual = false) = ComplexSpace(dims...; dual = dual)
 
 # convenience constructor
 Base.:^(::ComplexNumbers, d::Int) = ComplexSpace(d)

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -56,6 +56,7 @@ end
     @test isa(V, CartesianSpace)
     @test !isdual(V)
     @test !isdual(V')
+    @test V == CartesianSpace(Trivial() => d) == CartesianSpace(Dict(Trivial() => d))
     @test @inferred(hash(V)) == hash(deepcopy(V))
     @test V == @inferred(dual(V)) == @inferred(conj(V)) == @inferred(adjoint(V))
     @test field(V) == ℝ
@@ -91,6 +92,7 @@ end
     @test isa(V, ComplexSpace)
     @test !isdual(V)
     @test isdual(V')
+    @test V == ComplexSpace(Trivial() => d) == ComplexSpace(Dict(Trivial() => d))
     @test @inferred(hash(V)) == hash(deepcopy(V)) != hash(V')
     @test @inferred(dual(V)) == @inferred(conj(V)) == @inferred(adjoint(V)) != V
     @test @inferred(field(V)) == ℂ


### PR DESCRIPTION
I changed the code a bit from what we discussed earlier, to not have the method signatures be too restricted.