### PR TITLE
foldright frobeniusschur

### DIFF
--- a/src/fusiontrees/manipulations.jl
+++ b/src/fusiontrees/manipulations.jl
@@ -304,7 +304,7 @@ function foldright(f1::FusionTree{I, N₁}, f2::FusionTree{I, N₂}) where {I<:S
         c = first(c1 ⊗ c2)
         fl = FusionTree{I}(Base.tail(f1.uncoupled), c, Base.tail(f1.isdual))
         fr = FusionTree{I}((c1, f2.uncoupled...), c, (!isduala, f2.isdual...))
-        return fusiontreedict(I)((fl,fr)=>1)
+        return fusiontreedict(I)((fl, fr) => factor)
     else
         a = f1.uncoupled[1]
         isduala = f1.isdual[1]


### PR DESCRIPTION
Possibly does not take into account quantum dimension and Frobenius Schur indicator in the case of UniqueFusion, coefficient hardcoded to 1 (end of line 307). This might be generally true for UniqueFusion style, however then probably no need for calculating factor (line 298-301)?