### PR TITLE
truncated eigh function

### DIFF
--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -65,7 +65,7 @@ export dot, norm, normalize, normalize!, tr
 export mul!, lmul!, rmul!, adjoint!, pinv, axpy!, axpby!
 export leftorth, rightorth, leftnull, rightnull,
         leftorth!, rightorth!, leftnull!, rightnull!,
-        tsvd!, tsvd, eigen, eigen!, eig, eig!, eigh, eigh!, exp, exp!,
+        tsvd!, tsvd, eigen, eigen!, eig, eig!, eigh, eigh!, teigh, teigh!, exp, exp!,
         isposdef, isposdef!, ishermitian, sylvester
 export braid!, permute!, transpose!, twist!
 export catdomain, catcodomain


### PR DESCRIPTION
Hi Jutho, I've come across the necessity of using a truncated eigen decomposition, e.g. in this [time evolution algorithm](https://arxiv.org/pdf/2005.06104.pdf) or in the multiplication of MPO * MPS using the [density matrix algorithm](https://tensornetwork.org/mps/algorithms/denmat_mpo_mps/). Since TensorKit implements truncations only for SVDs, I thought I give it a try to implement a truncated eigh function.

In the code I reversed the order of the eigen values to be able to use the `_truncate!` function, which now makes the output of `eigh(t)` and `teigh(t, trunc = NoTruncation())` inconsistent. I don't know what your preference for sorting is, but this would need some further changes.

If this is a useful function for TensorKit, I would be happy to help finalize an implementation.