### PR TITLE
spacetype abstract types to traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *-old
 __pycache__
 .ipynb*
+Manifest.toml

--- a/docs/src/lib/spaces.md
+++ b/docs/src/lib/spaces.md
@@ -11,8 +11,6 @@ Field
 VectorSpace
 ElementarySpace
 GeneralSpace
-InnerProductSpace
-EuclideanSpace
 CartesianSpace
 ComplexSpace
 GradedSpace

--- a/docs/src/man/sectors.md
+++ b/docs/src/man/sectors.md
@@ -647,9 +647,9 @@ as illustrated below.
 We have introduced `Sector` subtypes as a way to label the irreps or sectors in the
 decomposition ``V = ⨁_a ℂ^{n_a} ⊗ R_{a}``. To actually represent such spaces, we now also
 introduce a corresponding type `GradedSpace`, which is a subtype of
-`EuclideanSpace{ℂ}`, i.e.
+`ElementarySpace{ℂ}`, i.e.
 ```julia
-struct GradedSpace{I<:Sector, D} <: EuclideanSpace{ℂ}
+struct GradedSpace{I<:Sector, D} <: ElementarySpace{ℂ}
     dims::D
     dual::Bool
 end

--- a/docs/src/man/spaces.md
+++ b/docs/src/man/spaces.md
@@ -103,40 +103,35 @@ struct GeneralSpace{𝕜} <: ElementarySpace{𝕜}
 end
 ```
 
-We furthermore define the abstract type
+We furthermore define the trait types
 ```julia
-abstract type InnerProductSpace{𝕜} <: ElementarySpace{𝕜} end
+abstract type InnerProductStyle end
+struct NoInnerProduct <: InnerProductStyle end
+abstract type HasInnerProduct <: InnerProductStyle end
+struct EuclideanProduct <: HasInnerProduct end
 ```
-to contain all vector spaces `V` which have an inner product and thus a canonical mapping
-from `dual(V)` to `V` (for `𝕜 ⊆ ℝ`) or from `dual(V)` to `conj(V)` (otherwise). This
-mapping is provided by the metric, but no further support for working with metrics is
+to denote for a vector space `V` whether it has an inner product and thus a canonical
+mapping from `dual(V)` to `V` (for `𝕜 ⊆ ℝ`) or from `dual(V)` to `conj(V)` (otherwise).
+This mapping is provided by the metric, but no further support for working with metrics is
 currently implemented.
 
-Finally there is
+The `EuclideanProduct` has the natural isomorphisms `dual(V) == V` (for `𝕜 == ℝ`)
+or `dual(V) == conj(V)` (for ` 𝕜 == ℂ`).
+In the language of the previous section on [categories](@ref s_categories), this trait represents [dagger or unitary categories](@ref ss_adjoints), and these vector spaces support an `adjoint` operation.
+
+In particular, the two concrete types
 ```julia
-abstract type EuclideanSpace{𝕜} <: InnerProductSpace{𝕜} end
-```
-to contain all spaces `V` with a standard Euclidean inner product (i.e. where the metric is
-the identity). These spaces have the natural isomorphisms `dual(V) == V` (for `𝕜 == ℝ`)
-or `dual(V) == conj(V)` (for ` 𝕜 == ℂ`). In the language of the previous section on
-[categories](@ref s_categories), this subtype represents
-[dagger or unitary categories](@ref ss_adjoints), and support an `adjoint` operation. In
-particular, we have two concrete types
-```julia
-struct CartesianSpace <: EuclideanSpace{ℝ}
+struct CartesianSpace <: ElementarySpace{ℝ}
     d::Int
 end
-struct ComplexSpace <: EuclideanSpace{ℂ}
+struct ComplexSpace <: ElementarySpace{ℂ}
   d::Int
   dual::Bool
 end
 ```
-to represent the Euclidean spaces $ℝ^d$ or $ℂ^d$ without further inner structure. They can
-be created using the syntax `CartesianSpace(d) == ℝ^d == ℝ[d]` and
-`ComplexSpace(d) == ℂ^d == ℂ[d]`, or
-`ComplexSpace(d, true) == ComplexSpace(d; dual = true) == (ℂ^d)' == ℂ[d]'` for the
-dual space of the latter. Note that the brackets are required because of the precedence
-rules, since `d' == d` for `d::Integer`.
+represent the Euclidean spaces $ℝ^d$ or $ℂ^d$ without further inner structure.
+They can be created using the syntax `CartesianSpace(d) == ℝ^d == ℝ[d]` and `ComplexSpace(d) == ℂ^d == ℂ[d]`, or `ComplexSpace(d, true) == ComplexSpace(d; dual = true) == (ℂ^d)' == ℂ[d]'` for the dual space of the latter.
+Note that the brackets are required because of the precedence rules, since `d' == d` for `d::Integer`.
 
 Some examples:
 ```@repl tensorkit
@@ -149,12 +144,15 @@ dual(ℂ^5) == (ℂ^5)' == conj(ℂ^5) == ComplexSpace(5; dual = true)
 typeof(ℝ^3)
 spacetype(ℝ^3)
 spacetype(ℝ[])
+InnerProductStyle(ℝ^3)
+InnerProductStyle(ℂ^5)
 ```
+
 Note that `ℝ[]` and `ℂ[]` are synonyms for `CartesianSpace` and `ComplexSpace` respectively,
 such that yet another syntax is e.g. `ℂ[](d)`. This is not very useful in itself, and is
 motivated by its generalization to `GradedSpace`. We refer to the subsection on
 [graded spaces](@ref s_rep) on the [next page](@ref s_sectorsrepfusion) for further
-information about `GradedSpace`, which is another subtype of `EuclideanSpace{ℂ}`
+information about `GradedSpace`, which is another subtype of `ElementarySpace{ℂ}`
 with an inner structure corresponding to the irreducible representations of a group, or more
 generally, the simple objects of a fusion category.
 
@@ -279,7 +277,7 @@ For completeness, we also export the strict comparison operators `≺` and `≻`
 ```
 However, as we expect these to be less commonly used, no ASCII alternative is provided.
 
-In the context of `spacetype(V) <: EuclideanSpace`, `V1 ≾ V2` implies that there exists
+In the context of `InnerProductStyle(V) <: EuclideanProduct`, `V1 ≾ V2` implies that there exists
 isometries ``W:V1 → V2`` such that ``W^† ∘ W = \mathrm{id}_{V1}``, while `V1 ≅ V2` implies
 that there exist unitaries ``U:V1→V2`` such that ``U^† ∘ U = \mathrm{id}_{V1}`` and
 ``U ∘ U^† = \mathrm{id}_{V2}``.

--- a/docs/src/man/tutorial.md
+++ b/docs/src/man/tutorial.md
@@ -28,12 +28,10 @@ V = ℝ^3
 typeof(V)
 V == CartesianSpace(3)
 supertype(CartesianSpace)
-supertype(EuclideanSpace)
-supertype(InnerProductSpace)
 supertype(ElementarySpace)
 ```
 i.e. `ℝ^n` can also be created without Unicode using the longer syntax `CartesianSpace(n)`.
-It is subtype of `EuclideanSpace{ℝ}`, a space with a standard (Euclidean) inner product
+It is subtype of `ElementarySpace{ℝ}`, with a standard (Euclidean) inner product
 over the real numbers. Furthermore,
 ```@repl tutorial
 W = ℝ^3 ⊗ ℝ^2 ⊗ ℝ^4

--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -17,7 +17,8 @@ export Fermion, FermionParity, FermionNumber, FermionSpin
 export FibonacciAnyon
 export IsingAnyon
 
-export VectorSpace, Field, ElementarySpace, InnerProductSpace, EuclideanSpace # abstract vector spaces
+export VectorSpace, Field, ElementarySpace # abstract vector spaces
+export InnerProductStyle, NoInnerProduct, HasInnerProduct, EuclideanProduct
 export ComplexSpace, CartesianSpace, GeneralSpace, GradedSpace # concrete spaces
 export ZNSpace, Z2Space, Z3Space, Z4Space, U1Space, CU1Space, SU2Space
 export Vect, Rep # space constructors

--- a/src/spaces/cartesianspace.jl
+++ b/src/spaces/cartesianspace.jl
@@ -1,11 +1,11 @@
 """
-    struct CartesianSpace <: EuclideanSpace{ℝ}
+    struct CartesianSpace <: ElementarySpace{ℝ}
 
 A real Euclidean space `ℝ^d`, which is therefore self-dual. `CartesianSpace` has no
 additonal structure and is completely characterised by its dimension `d`. This is the
 vector space that is implicitly assumed in most of matrix algebra.
 """
-struct CartesianSpace <: EuclideanSpace{ℝ}
+struct CartesianSpace <: ElementarySpace{ℝ}
     d::Int
 end
 CartesianSpace(d::Integer = 0; dual = false) = CartesianSpace(Int(d))
@@ -27,6 +27,10 @@ function CartesianSpace(dims::AbstractDict; kwargs...)
         throw(SectorMismatch(msg))
     end
 end
+
+InnerProductStyle(::Type{CartesianSpace}) = EuclideanProduct()
+
+isdual(V::CartesianSpace) = false
 
 # convenience constructor
 Base.getindex(::RealNumbers) = CartesianSpace

--- a/src/spaces/complexspace.jl
+++ b/src/spaces/complexspace.jl
@@ -1,13 +1,13 @@
 """
-    struct ComplexSpace <: EuclideanSpace{ℂ}
+    struct ComplexSpace <: ElementarySpace{ℂ}
 
 A standard complex vector space ℂ^d with Euclidean inner product and no additional
 structure. It is completely characterised by its dimension and whether its the normal space
 or its dual (which is canonically isomorphic to the conjugate space).
 """
-struct ComplexSpace <: EuclideanSpace{ℂ}
-  d::Int
-  dual::Bool
+struct ComplexSpace <: ElementarySpace{ℂ}
+    d::Int
+    dual::Bool
 end
 ComplexSpace(d::Integer = 0; dual = false) = ComplexSpace(Int(d), dual)
 function ComplexSpace(dim::Pair; dual = false)
@@ -29,6 +29,8 @@ function ComplexSpace(dims::AbstractDict; kwargs...)
     end
 end
 
+InnerProductStyle(::Type{ComplexSpace}) = EuclideanProduct()
+
 # convenience constructor
 Base.getindex(::ComplexNumbers) = ComplexSpace
 Base.:^(::ComplexNumbers, d::Int) = ComplexSpace(d)
@@ -42,17 +44,23 @@ Base.axes(V::ComplexSpace) = Base.OneTo(dim(V))
 Base.conj(V::ComplexSpace) = ComplexSpace(dim(V), !isdual(V))
 
 Base.oneunit(::Type{ComplexSpace}) = ComplexSpace(1)
-⊕(V1::ComplexSpace, V2::ComplexSpace) = isdual(V1) == isdual(V2) ?
-    ComplexSpace(dim(V1)+dim(V2), isdual(V1)) :
-    throw(SpaceMismatch("Direct sum of a vector space and its dual does not exist"))
-fuse(V1::ComplexSpace, V2::ComplexSpace) = ComplexSpace(V1.d*V2.d)
+function ⊕(V1::ComplexSpace, V2::ComplexSpace)
+    return isdual(V1) == isdual(V2) ?
+           ComplexSpace(dim(V1) + dim(V2), isdual(V1)) :
+           throw(SpaceMismatch("Direct sum of a vector space and its dual does not exist"))
+end
+fuse(V1::ComplexSpace, V2::ComplexSpace) = ComplexSpace(V1.d * V2.d)
 flip(V::ComplexSpace) = dual(V)
 
-infimum(V1::ComplexSpace, V2::ComplexSpace) = isdual(V1) == isdual(V2) ?
-    ComplexSpace(min(dim(V1), dim(V2)), isdual(V1)) :
-    throw(SpaceMismatch("Infimum of space and dual space does not exist"))
-supremum(V1::ComplexSpace, V2::ComplexSpace) = isdual(V1) == isdual(V2) ?
-    ComplexSpace(max(dim(V1), dim(V2)), isdual(V1)) :
-    throw(SpaceMismatch("Supremum of space and dual space does not exist"))
+function infimum(V1::ComplexSpace, V2::ComplexSpace)
+    return isdual(V1) == isdual(V2) ?
+           ComplexSpace(min(dim(V1), dim(V2)), isdual(V1)) :
+           throw(SpaceMismatch("Infimum of space and dual space does not exist"))
+end
+function supremum(V1::ComplexSpace, V2::ComplexSpace)
+    return isdual(V1) == isdual(V2) ?
+           ComplexSpace(max(dim(V1), dim(V2)), isdual(V1)) :
+           throw(SpaceMismatch("Supremum of space and dual space does not exist"))
+end
 
 Base.show(io::IO, V::ComplexSpace) = print(io, isdual(V) ? "(ℂ^$(V.d))'" : "ℂ^$(V.d)")

--- a/src/spaces/deligne.jl
+++ b/src/spaces/deligne.jl
@@ -15,35 +15,36 @@ natural representation spaces of the direct product of two groups.
 ⊠(V1::VectorSpace, V2::VectorSpace) = (V1 ⊠ one(V2)) ⊗ (one(V1) ⊠ V2)
 
 # define deligne products with empty tensor product: just add a trivial sector of the type of the empty space to each of the sectors in the non-empty space
-function ⊠(V::GradedSpace, P0::ProductSpace{<:EuclideanSpace{ℂ},0})
+function ⊠(V::GradedSpace, P0::ProductSpace{<:ElementarySpace{ℂ},0})
     I1 = sectortype(V)
     I2 = sectortype(P0)
     return Vect[I1 ⊠ I2](ifelse(isdual(V), dual(c), c) ⊠ one(I2) => dim(V, c) for c in sectors(V); dual = isdual(V))
 end
 
-function ⊠(P0::ProductSpace{<:EuclideanSpace{ℂ},0}, V::GradedSpace)
+function ⊠(P0::ProductSpace{<:ElementarySpace{ℂ},0}, V::GradedSpace)
     I1 = sectortype(P0)
     I2 = sectortype(V)
     return Vect[I1 ⊠ I2](one(I1) ⊠ ifelse(isdual(V), dual(c), c) => dim(V, c) for c in sectors(V); dual = isdual(V))
 end
 
-function ⊠(V::ComplexSpace, P0::ProductSpace{<:EuclideanSpace{ℂ},0})
+function ⊠(V::ComplexSpace, P0::ProductSpace{<:ElementarySpace{ℂ},0})
     I2 = sectortype(P0)
     return Vect[I2](one(I2) => dim(V); dual = isdual(V))
 end
 
-function ⊠(P0::ProductSpace{<:EuclideanSpace{ℂ},0}, V::ComplexSpace)
+function ⊠(P0::ProductSpace{<:ElementarySpace{ℂ},0}, V::ComplexSpace)
     I1 = sectortype(P0)
     return Vect[I1](one(I1) => dim(V); dual = isdual(V))
 end
 
-function ⊠(P::ProductSpace{<:EuclideanSpace{ℂ},0}, P0::ProductSpace{<:EuclideanSpace{ℂ},0})
+function ⊠(P::ProductSpace{<:ElementarySpace{ℂ},0},
+           P0::ProductSpace{<:ElementarySpace{ℂ},0})
     I1 = sectortype(P)
     I2 = sectortype(P0)
     return one(Vect[I1 ⊠ I2])
 end
 
-function ⊠(P::ProductSpace{<:EuclideanSpace{ℂ}}, P0::ProductSpace{<:EuclideanSpace{ℂ},0})
+function ⊠(P::ProductSpace{<:ElementarySpace{ℂ}}, P0::ProductSpace{<:ElementarySpace{ℂ},0})
     I1 = sectortype(P)
     I2 = sectortype(P0)
     S = Vect[I1 ⊠ I2]
@@ -51,7 +52,7 @@ function ⊠(P::ProductSpace{<:EuclideanSpace{ℂ}}, P0::ProductSpace{<:Euclidea
     return ProductSpace{S,N}(map(V->V ⊠ P0, tuple(P...)))
 end
 
-function ⊠(P0::ProductSpace{<:EuclideanSpace{ℂ},0}, P::ProductSpace{<:EuclideanSpace{ℂ}})
+function ⊠(P0::ProductSpace{<:ElementarySpace{ℂ},0}, P::ProductSpace{<:ElementarySpace{ℂ}})
     I1 = sectortype(P0)
     I2 = sectortype(P)
     S = Vect[I1 ⊠ I2]

--- a/src/spaces/generalspace.jl
+++ b/src/spaces/generalspace.jl
@@ -28,10 +28,10 @@ isconj(V::GeneralSpace) = V.conj
 
 Base.axes(V::GeneralSpace) = Base.OneTo(dim(V))
 
-dual(V::GeneralSpace{𝕜}) where {𝕜} =
-    GeneralSpace{𝕜}(dim(V), !isdual(V), isconj(V))
-Base.conj(V::GeneralSpace{𝕜}) where {𝕜} =
-    GeneralSpace{𝕜}(dim(V), isdual(V), !isconj(V))
+InnerProductStyle(::Type{<:GeneralSpace}) = NoInnerProduct()
+
+dual(V::GeneralSpace{𝕜}) where {𝕜} = GeneralSpace{𝕜}(dim(V), !isdual(V), isconj(V))
+Base.conj(V::GeneralSpace{𝕜}) where {𝕜} = GeneralSpace{𝕜}(dim(V), isdual(V), !isconj(V))
 
 function Base.show(io::IO, V::GeneralSpace{𝕜}) where {𝕜}
     if isconj(V)

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -16,7 +16,11 @@ codomain(W::HomSpace) = W.codomain
 domain(W::HomSpace) = W.domain
 
 dual(W::HomSpace) = HomSpace(dual(W.domain), dual(W.codomain))
-Base.adjoint(W::HomSpace{<:EuclideanSpace}) = HomSpace(W.domain, W.codomain)
+function Base.adjoint(W::HomSpace{S}) where {S}
+    InnerProductStyle(S) === EuclideanProduct() ||
+        throw(ArgumentError("adjoint requires Euclidean inner product"))
+    return HomSpace(W.domain, W.codomain)
+end
 
 Base.hash(W::HomSpace, h::UInt) = hash(domain(W), hash(codomain(W), h))
 Base.:(==)(W1::HomSpace, W2::HomSpace) =

--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -560,7 +560,7 @@ end
 function LinearAlgebra.isposdef!(t::TensorMap)
     domain(t) == codomain(t) ||
         throw(SpaceMismatch("`isposdef` requires domain and codomain to be the same"))
-    spacetype(t) <: EuclideanSpace || return false
+    InnerProductStyle(spacetype(t)) === EuclideanProduct() || return false
     for (c, b) in blocks(t)
         isposdef!(b) || return false
     end

--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -47,8 +47,8 @@ singular values that were truncated.
 THe keyword `alg` can be equal to `SVD()` or `SDD()`, corresponding to the underlying LAPACK
 algorithm that computes the decomposition (`_gesvd` or `_gesdd`).
 
-Orthogonality requires `InnerProductStyle(spacetype(t)) <: HasInnerProduct`, and `tsvd(!)`
-is currently only implemented for `InnerProductStyle(spacetype(t)) === EuclideanProduct()`.
+Orthogonality requires `InnerProductStyle(t) <: HasInnerProduct`, and `tsvd(!)`
+is currently only implemented for `InnerProductStyle(t) === EuclideanProduct()`.
 """
 tsvd(t::AbstractTensorMap, p1::IndexTuple, p2::IndexTuple; kwargs...) =
     tsvd!(permute(t, p1, p2; copy = true); kwargs...)
@@ -71,9 +71,9 @@ standard QR decomposition such that the diagonal elements of `R` are positive. O
 `QRpos()` and `Polar()` are uniqe (no residual freedom) so that they always return the same
 result for the same input tensor `t`.
 
-Orthogonality requires `InnerProductStyle(spacetype(t)) <: HasInnerProduct`, and
+Orthogonality requires `InnerProductStyle(t) <: HasInnerProduct`, and
 `leftorth(!)` is currently only implemented for 
-    `InnerProductStyle(spacetype(t)) === EuclideanProduct()`.
+    `InnerProductStyle(t) === EuclideanProduct()`.
 """
 leftorth(t::AbstractTensorMap, p1::IndexTuple, p2::IndexTuple; kwargs...) =
     leftorth!(permute(t, p1, p2; copy = true); kwargs...)
@@ -98,9 +98,9 @@ diagonal elements of `L` are positive. `Polar()` produces a Hermitian and positi
 semidefinite `L`. Only `LQpos()`, `RQpos()` and `Polar()` are uniqe (no residual freedom) so
 that they always return the same result for the same input tensor `t`.
 
-Orthogonality requires `InnerProductStyle(spacetype(t)) <: HasInnerProduct`, and
+Orthogonality requires `InnerProductStyle(t) <: HasInnerProduct`, and
 `rightorth(!)` is currently only implemented for 
-`InnerProductStyle(spacetype(t)) === EuclideanProduct()`.
+`InnerProductStyle(t) === EuclideanProduct()`.
 """
 rightorth(t::AbstractTensorMap, p1::IndexTuple, p2::IndexTuple; kwargs...) =
     rightorth!(permute(t, p1, p2; copy = true); kwargs...)
@@ -123,9 +123,9 @@ value decomposition, and one can specify an absolute or relative tolerance for w
 singular values are to be considered zero, where `max(atol, norm(t)*rtol)` is used as upper
 bound.
 
-Orthogonality requires `InnerProductStyle(spacetype(t)) <: HasInnerProduct`, and
+Orthogonality requires `InnerProductStyle(t) <: HasInnerProduct`, and
 `leftnull(!)` is currently only implemented for 
-`InnerProductStyle(spacetype(t)) === EuclideanProduct()`.
+`InnerProductStyle(t) === EuclideanProduct()`.
 """
 leftnull(t::AbstractTensorMap, p1::IndexTuple, p2::IndexTuple; kwargs...) =
     leftnull!(permute(t, p1, p2; copy = true); kwargs...)
@@ -150,9 +150,9 @@ value decomposition, and one can specify an absolute or relative tolerance for w
 singular values are to be considered zero, where `max(atol, norm(t)*rtol)` is used as upper
 bound.
 
-Orthogonality requires `InnerProductStyle(spacetype(t)) <: HasInnerProduct`, and
+Orthogonality requires `InnerProductStyle(t) <: HasInnerProduct`, and
 `rightnull(!)` is currently only implemented for 
-`InnerProductStyle(spacetype(t)) === EuclideanProduct()`.
+`InnerProductStyle(t) === EuclideanProduct()`.
 """
 rightnull(t::AbstractTensorMap, p1::IndexTuple, p2::IndexTuple; kwargs...) =
     rightnull!(permute(t, p1, p2; copy = true); kwargs...)
@@ -210,7 +210,7 @@ Compute eigenvalue factorization of tensor `t` as linear map from `rightind` to 
 The function `eigh` assumes that the linear map is hermitian and `D` and `V` tensors with
 the same `eltype` as `t`. See `eig` and `eigen` for non-hermitian tensors. Hermiticity
 requires that the tensor acts on inner product spaces, and the current implementation
-requires `InnerProductStyle(spacetype(t)) === EuclideanProduct()`.
+requires `InnerProductStyle(t) === EuclideanProduct()`.
 
 If `leftind` and `rightind` are not specified, the current partition of left and right
 indices of `t` is used. In that case, less memory is allocated if one allows the data in
@@ -264,27 +264,27 @@ LinearAlgebra.isposdef(t::AbstractTensorMap) = isposdef!(copy(t))
 # only correct if Euclidean inner product
 #------------------------------------------------------------------------------------------
 function leftorth!(t::AdjointTensorMap; alg::OFA=QRpos())
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("leftorth! only defined for Euclidean inner product spaces"))
     return map(adjoint, reverse(rightorth!(adjoint(t); alg=alg')))
 end
 
 function rightorth!(t::AdjointTensorMap; alg::OFA=LQpos())
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("rightorth! only defined for Euclidean inner product spaces"))
     return map(adjoint, reverse(leftorth!(adjoint(t); alg=alg')))
 end
 
 function leftnull!(t::AdjointTensorMap; alg::OFA=QR(),
                    kwargs...)
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("leftnull! only defined for Euclidean inner product spaces"))
     return adjoint(rightnull!(adjoint(t); alg=alg', kwargs...))
 end
 
 function rightnull!(t::AdjointTensorMap; alg::OFA=LQ(),
                     kwargs...)
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("rightnull! only defined for Euclidean inner product spaces"))
     return adjoint(leftnull!(adjoint(t); alg=alg', kwargs...))
 end
@@ -293,7 +293,7 @@ function tsvd!(t::AdjointTensorMap;
                trunc::TruncationScheme=NoTruncation(),
                p::Real=2,
                alg::Union{SVD,SDD}=SDD())
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("tsvd! only defined for Euclidean inner product spaces"))
 
     u, s, vt, err = tsvd!(adjoint(t); trunc=trunc, p=p, alg=alg)
@@ -305,7 +305,7 @@ function leftorth!(t::TensorMap;
                    atol::Real=zero(float(real(eltype(t)))),
                    rtol::Real=(alg ∉ (SVD(), SDD())) ? zero(float(real(eltype(t)))) :
                               eps(real(float(one(eltype(t))))) * iszero(atol))
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("leftorth! only defined for Euclidean inner product spaces"))
     if !iszero(rtol)
         atol = max(atol, rtol*norm(t))
@@ -342,7 +342,7 @@ function leftnull!(t::TensorMap;
                    atol::Real=zero(float(real(eltype(t)))),
                    rtol::Real=(alg ∉ (SVD(), SDD())) ? zero(float(real(eltype(t)))) :
                               eps(real(float(one(eltype(t))))) * iszero(atol))
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("leftnull! only defined for Euclidean inner product spaces"))
     if !iszero(rtol)
         atol = max(atol, rtol*norm(t))
@@ -367,7 +367,7 @@ function rightorth!(t::TensorMap;
                     atol::Real=zero(float(real(eltype(t)))),
                     rtol::Real=(alg ∉ (SVD(), SDD())) ? zero(float(real(eltype(t)))) :
                                eps(real(float(one(eltype(t))))) * iszero(atol))
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("rightorth! only defined for Euclidean inner product spaces"))
     if !iszero(rtol)
         atol = max(atol, rtol*norm(t))
@@ -404,7 +404,7 @@ function rightnull!(t::TensorMap;
                     atol::Real=zero(float(real(eltype(t)))),
                     rtol::Real=(alg ∉ (SVD(), SDD())) ? zero(float(real(eltype(t)))) :
                                eps(real(float(one(eltype(t))))) * iszero(atol))
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("rightnull! only defined for Euclidean inner product spaces"))
     if !iszero(rtol)
         atol = max(atol, rtol*norm(t))
@@ -428,7 +428,7 @@ function tsvd!(t::TensorMap;
                trunc::TruncationScheme=NoTruncation(),
                p::Real=2,
                alg::Union{SVD,SDD}=SDD())
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("tsvd! only defined for Euclidean inner product spaces"))
     S = spacetype(t)
     I = sectortype(t)
@@ -492,7 +492,7 @@ end
 
 function LinearAlgebra.ishermitian(t::TensorMap)
     domain(t) == codomain(t) || return false
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() || return false # hermiticity only defined for euclidean
+    InnerProductStyle(t) === EuclideanProduct() || return false # hermiticity only defined for euclidean
     for (c, b) in blocks(t)
         ishermitian(b) || return false
     end
@@ -502,7 +502,7 @@ end
 LinearAlgebra.eigen!(t::TensorMap) = ishermitian(t) ? eigh!(t) : eig!(t)
 
 function eigh!(t::TensorMap; kwargs...)
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("eigh! only defined for Euclidean inner product spaces"))
     domain(t) == codomain(t) ||
         throw(SpaceMismatch("`eigh!` requires domain and codomain to be the same"))

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -68,7 +68,7 @@ and error will be thrown. When they are isomorphic, there is no canonical choice
 specific isomorphism, but the current choice is such that
 `isomorphism(cod, dom) == inv(isomorphism(dom, cod))`.
 
-See also [`unitary`](@ref) when `spacetype(cod) isa EuclideanSpace`.
+See also [`unitary`](@ref) when `InnerProductStyle(spacetype(cod)) === EuclideanProduct()`.
 """
 isomorphism(cod::TensorSpace, dom::TensorSpace) = isomorphism(Matrix{Float64}, cod, dom)
 isomorphism(P::TensorMapSpace) = isomorphism(codomain(P), domain(P))
@@ -85,50 +85,60 @@ function isomorphism(::Type{A}, cod::ProductSpace, dom::ProductSpace) where {A<:
     return t
 end
 
-const EuclideanTensorSpace = TensorSpace{<:EuclideanSpace}
-const EuclideanTensorMapSpace = TensorMapSpace{<:EuclideanSpace}
-const AbstractEuclideanTensorMap = AbstractTensorMap{<:EuclideanTensorSpace}
-const EuclideanTensorMap = TensorMap{<:EuclideanTensorSpace}
-
 """
     unitary([A::Type{<:DenseMatrix} = Matrix{Float64},] cod::VectorSpace, dom::VectorSpace)
     -> TensorMap
 
 Return a `t::TensorMap` that implements a specific unitary isomorphism between the codomain
-`cod` and the domain `dom`, for which `spacetype(dom)` (`== spacetype(cod)`) must be a
-subtype of `EuclideanSpace`. Furthermore, `storagetype(t)` can optionally be chosen to be
+`cod` and the domain `dom`, for which `spacetype(dom)` (`== spacetype(cod)`) must have an
+inner product. Furthermore, `storagetype(t)` can optionally be chosen to be
 of type `A`. If the two spaces do not allow for such an isomorphism, and are thus not
 isomorphic, and error will be thrown. When they are isomorphic, there is no canonical choice
 for a specific isomorphism, but the current choice is such that
 `unitary(cod, dom) == inv(unitary(dom, cod)) = adjoint(unitary(dom, cod))`.
 """
-unitary(cod::EuclideanTensorSpace, dom::EuclideanTensorSpace) = isomorphism(cod, dom)
-unitary(P::EuclideanTensorMapSpace) = isomorphism(P)
-unitary(A::Type{<:DenseMatrix}, P::EuclideanTensorMapSpace) = isomorphism(A, P)
-unitary(A::Type{<:DenseMatrix}, cod::EuclideanTensorSpace, dom::EuclideanTensorSpace) =
-    isomorphism(A, cod, dom)
+function unitary(cod::TensorSpace{S}, dom::TensorSpace{S}) where {S}
+    InnerProductStyle(S) === EuclideanProduct() || 
+        throw(ArgumentError("unitary requires inner product spaces"))
+    return isomorphism(cod, dom)
+end
+function unitary(P::TensorMapSpace{S}) where {S}
+    InnerProductStyle(S) === EuclideanProduct() ||
+        throw(ArgumentError("unitary requires inner product spaces"))
+    return isomorphism(P)
+end
+function unitary(A::Type{<:DenseMatrix}, P::TensorMapSpace{S}) where {S}
+    InnerProductStyle(S) === EuclideanProduct() ||
+        throw(ArgumentError("unitary requires inner product spaces"))
+    return isomorphism(A, P)
+end
+function unitary(A::Type{<:DenseMatrix}, cod::TensorSpace{S}, dom::TensorSpace{S}) where {S}
+    InnerProductStyle(S) === EuclideanProduct() ||
+        throw(ArgumentError("unitary requires inner product spaces"))
+    return isomorphism(A, cod, dom)
+end
 
 """
     isometry([A::Type{<:DenseMatrix} = Matrix{Float64},] cod::VectorSpace, dom::VectorSpace)
     -> TensorMap
 
 Return a `t::TensorMap` that implements a specific isometry that embeds the domain `dom`
-into the codomain `cod`, and which requires that `spacetype(dom)` (`== spacetype(cod)`) is
-a subtype of `EuclideanSpace`. An isometry `t` is such that its adjoint `t'` is the left
+into the codomain `cod`, and which requires that `spacetype(dom)` (`== spacetype(cod)`) has
+an Euclidean inner product. An isometry `t` is such that its adjoint `t'` is the left
 inverse of `t`, i.e. `t'*t = id(dom)`, while `t*t'` is some idempotent endomorphism of
 `cod`, i.e. it squares to itself. When `dom` and `cod` do not allow for such an isometric
 inclusion, an error will be thrown.
 """
-isometry(cod::EuclideanTensorSpace, dom::EuclideanTensorSpace) =
-    isometry(Matrix{Float64}, cod, dom)
-isometry(P::EuclideanTensorMapSpace) = isometry(codomain(P), domain(P))
-isometry(A::Type{<:DenseMatrix}, P::EuclideanTensorMapSpace) =
-    isometry(A, codomain(P), domain(P))
-isometry(A::Type{<:DenseMatrix}, cod::EuclideanTensorSpace, dom::EuclideanTensorSpace) =
+isometry(cod::TensorSpace, dom::TensorSpace) = isometry(Matrix{Float64}, cod, dom)
+isometry(P::TensorMapSpace) = isometry(codomain(P), domain(P))
+isometry(A::Type{<:DenseMatrix}, P::TensorMapSpace) = isometry(A, codomain(P), domain(P))
+isometry(A::Type{<:DenseMatrix}, cod::TensorSpace, dom::TensorSpace) =
     isometry(A, convert(ProductSpace, cod), convert(ProductSpace, dom))
 function isometry(::Type{A},
                     cod::ProductSpace{S},
-                    dom::ProductSpace{S}) where {A<:DenseMatrix, S<:EuclideanSpace}
+                    dom::ProductSpace{S}) where {A<:DenseMatrix, S<:ElementarySpace}
+    InnerProductStyle(S) === EuclideanProduct() ||
+        throw(ArgumentError("isometries require Euclidean inner product"))
     dom ≾ cod || throw(SpaceMismatch("codomain $cod and domain $dom do not allow for an isometric mapping"))
     t = TensorMap(s->A(undef, s), cod, dom)
     for (c, b) in blocks(t)
@@ -159,8 +169,10 @@ function Base.fill!(t::AbstractTensorMap, value::Number)
     end
     return t
 end
-function LinearAlgebra.adjoint!(tdst::AbstractEuclideanTensorMap,
-                                tsrc::AbstractEuclideanTensorMap)
+function LinearAlgebra.adjoint!(tdst::AbstractTensorMap,
+                                tsrc::AbstractTensorMap)
+    spacetype(tdst) === spacetype(tsrc) && InnerProductStyle(tdst) === EuclideanProduct() ||
+        throw(ArgumentError("adjoint! requires Euclidean inner product spacetype"))
     space(tdst) == adjoint(space(tsrc)) || throw(SpaceMismatch())
     for c in blocksectors(tdst)
         adjoint!(StridedView(block(tdst, c)), StridedView(block(tsrc, c)))
@@ -203,8 +215,10 @@ function LinearAlgebra.axpby!(α::Number, t1::AbstractTensorMap,
 end
 
 # inner product and norm only valid for spaces with Euclidean inner product
-function LinearAlgebra.dot(t1::AbstractEuclideanTensorMap, t2::AbstractEuclideanTensorMap)
+function LinearAlgebra.dot(t1::AbstractTensorMap, t2::AbstractTensorMap)
     space(t1) == space(t2) || throw(SpaceMismatch())
+    InnerProductStyle(spacetype(t1)) === EuclideanProduct() ||
+        throw(ArgumentError("dot requires Euclidean inner product"))
     T = promote_type(eltype(t1), eltype(t2))
     s = zero(T)
     for c in blocksectors(t1)
@@ -213,8 +227,11 @@ function LinearAlgebra.dot(t1::AbstractEuclideanTensorMap, t2::AbstractEuclidean
     return s
 end
 
-LinearAlgebra.norm(t::AbstractEuclideanTensorMap, p::Real = 2) =
-    _norm(blocks(t), p, float(zero(real(eltype(t)))))
+function LinearAlgebra.norm(t::AbstractTensorMap, p::Real = 2)
+    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+        throw(ArgumentError("norm requires Euclidean inner product"))
+    return _norm(blocks(t), p, float(zero(real(eltype(t)))))
+end
 function _norm(blockiter, p::Real, init::Real)
     if p == Inf
         return mapreduce(max, blockiter; init = init) do (c, b)
@@ -477,8 +494,8 @@ function ⊗(t1::AbstractTensorMap{S}, t2::AbstractTensorMap{S}) where S
 end
 
 # deligne product of tensors
-function ⊠(t1::AbstractTensorMap{<:EuclideanSpace{ℂ}},
-            t2::AbstractTensorMap{<:EuclideanSpace{ℂ}})
+function ⊠(t1::AbstractTensorMap{<:ElementarySpace{ℂ}},
+            t2::AbstractTensorMap{<:ElementarySpace{ℂ}})
     S1 = spacetype(t1)
     I1 = sectortype(S1)
     S2 = spacetype(t2)

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -68,7 +68,7 @@ and error will be thrown. When they are isomorphic, there is no canonical choice
 specific isomorphism, but the current choice is such that
 `isomorphism(cod, dom) == inv(isomorphism(dom, cod))`.
 
-See also [`unitary`](@ref) when `InnerProductStyle(spacetype(cod)) === EuclideanProduct()`.
+See also [`unitary`](@ref) when `InnerProductStyle(cod) === EuclideanProduct()`.
 """
 isomorphism(cod::TensorSpace, dom::TensorSpace) = isomorphism(Matrix{Float64}, cod, dom)
 isomorphism(P::TensorMapSpace) = isomorphism(codomain(P), domain(P))
@@ -217,7 +217,7 @@ end
 # inner product and norm only valid for spaces with Euclidean inner product
 function LinearAlgebra.dot(t1::AbstractTensorMap, t2::AbstractTensorMap)
     space(t1) == space(t2) || throw(SpaceMismatch())
-    InnerProductStyle(spacetype(t1)) === EuclideanProduct() ||
+    InnerProductStyle(t1) === EuclideanProduct() ||
         throw(ArgumentError("dot requires Euclidean inner product"))
     T = promote_type(eltype(t1), eltype(t2))
     s = zero(T)
@@ -228,7 +228,7 @@ function LinearAlgebra.dot(t1::AbstractTensorMap, t2::AbstractTensorMap)
 end
 
 function LinearAlgebra.norm(t::AbstractTensorMap, p::Real = 2)
-    InnerProductStyle(spacetype(t)) === EuclideanProduct() ||
+    InnerProductStyle(t) === EuclideanProduct() ||
         throw(ArgumentError("norm requires Euclidean inner product"))
     return _norm(blocks(t), p, float(zero(real(eltype(t)))))
 end

--- a/src/tensors/tensoroperations.jl
+++ b/src/tensors/tensoroperations.jl
@@ -18,9 +18,9 @@ function cached_permute(sym::Symbol, t::TensorMap{S},
     end
 end
 
-function cached_permute(sym::Symbol, t::AdjointTensorMap{S},
+function cached_permute(sym::Symbol, t::AdjointTensorMap,
                             p1::IndexTuple,  p2::IndexTuple=();
-                            copy::Bool = false) where {S, N₁, N₂}
+                            copy::Bool = false)
     p1′ = adjointtensorindices(t, p2)
     p2′ = adjointtensorindices(t, p1)
     adjoint(cached_permute(sym, adjoint(t), p1′, p2′; copy = copy))

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -51,8 +51,8 @@ end
     @test eval(Meta.parse(sprint(show, typeof(V)))) == typeof(V)
     @test isa(V, VectorSpace)
     @test isa(V, ElementarySpace)
-    @test isa(V, InnerProductSpace)
-    @test isa(V, EuclideanSpace)
+    @test isa(InnerProductStyle(V), HasInnerProduct)
+    @test isa(InnerProductStyle(V), EuclideanProduct)
     @test isa(V, CartesianSpace)
     @test !isdual(V)
     @test !isdual(V')
@@ -94,8 +94,8 @@ end
     @test eval(Meta.parse(sprint(show, typeof(V)))) == typeof(V)
     @test isa(V, VectorSpace)
     @test isa(V, ElementarySpace)
-    @test isa(V, InnerProductSpace)
-    @test isa(V, EuclideanSpace)
+    @test isa(InnerProductStyle(V), HasInnerProduct)
+    @test isa(InnerProductStyle(V), EuclideanProduct)
     @test isa(V, ComplexSpace)
     @test !isdual(V)
     @test isdual(V')
@@ -151,8 +151,8 @@ end
     @test TensorKit.isconj(conj(V'))
     @test isa(V, VectorSpace)
     @test isa(V, ElementarySpace)
-    @test !isa(V, InnerProductSpace)
-    @test !isa(V, EuclideanSpace)
+    @test !isa(InnerProductStyle(V), HasInnerProduct)
+    @test !isa(InnerProductStyle(V), EuclideanProduct)
     @test @constinferred(hash(V)) == hash(deepcopy(V)) != hash(V')
     @test @constinferred(dual(V)) != @constinferred(conj(V)) != V
     @test @constinferred(field(V)) == ℂ
@@ -206,8 +206,8 @@ end
     @test eval(Meta.parse(sprint(show, W))) == W
     @test isa(V, VectorSpace)
     @test isa(V, ElementarySpace)
-    @test isa(V, InnerProductSpace)
-    @test isa(V, EuclideanSpace)
+    @test isa(InnerProductStyle(V), HasInnerProduct)
+    @test isa(InnerProductStyle(V), EuclideanProduct)
     @test isa(V, GradedSpace)
     @test isa(V, GradedSpace{I})
     @test @constinferred(dual(V)) == @constinferred(conj(V)) == @constinferred(adjoint(V)) != V


### PR DESCRIPTION
* Removes `InnerProductSpace` and `EuclideanSpace` as abstract types.
* Adds `InnerProductStyle` as a trait based mechanism to query if a space has an inner product.
* Implements `NoInnerProduct`, `HasInnerProduct` and `EuclideanInnerProduct` as traits

Remark:
It might be clearer to remove this distinction altogether. I don't know of a current use of `GeneralSpace`, which is the only non-Euclidean spacetype to begin with. If we are happy with this design I'll update the docs as well