### PR TITLE
Rewrite the deduction of braidingtensor spaces

### DIFF
--- a/src/planar/macros.jl
+++ b/src/planar/macros.jl
@@ -23,7 +23,7 @@ function planarparser(planarexpr, kwargs...)
 
     # braiding tensors need to be instantiated before kwargs are processed
     push!(parser.preprocessors, _construct_braidingtensors)
-    
+
     for (name, val) in kwargs
         if name == :order
             isexpr(val, :tuple) ||
@@ -62,7 +62,7 @@ function planarparser(planarexpr, kwargs...)
             throw(ArgumentError("Unknown keyword argument `name`."))
         end
     end
-    
+
     treebuilder = parser.contractiontreebuilder
     treesorter = parser.contractiontreesorter
     costcheck = parser.contractioncostcheck

--- a/test/planar.jl
+++ b/test/planar.jl
@@ -71,29 +71,29 @@ end
 
 @testset "@planar" verbose = true begin
     T = ComplexF64
-    
+
     @testset "contractcheck" begin
         V = ℂ^2
         A = TensorMap(rand, T, V ⊗ V ← V)
         B = TensorMap(rand, T, V ⊗ V ← V')
         @tensor C1[i j; k l] := A[i j; m] * B[k l; m]
-        @tensor contractcheck=true C2[i j; k l] := A[i j; m] * B[k l; m]
+        @tensor contractcheck = true C2[i j; k l] := A[i j; m] * B[k l; m]
         @test C1 ≈ C2
         B2 = TensorMap(rand, T, V ⊗ V ← V) # wrong duality for third space
         @test_throws SpaceMismatch("incompatible spaces for m: $V ≠ $(V')") begin
             @tensor contractcheck = true C3[i j; k l] := A[i j; m] * B2[k l; m]
         end
-        
+
         A = TensorMap(rand, T, V ← V ⊗ V)
         B = TensorMap(rand, T, V ⊗ V ← V)
         @planar C1[i; j] := A[i; k l] * τ[k l; m n] * B[m n; j]
-        @planar contractcheck=true C2[i; j] := A[i; k l] * τ[k l; m n] * B[m n; j]
+        @planar contractcheck = true C2[i; j] := A[i; k l] * τ[k l; m n] * B[m n; j]
         @test C1 ≈ C2
         @test_throws SpaceMismatch("incompatible spaces for l: $V ≠ $(V')") begin
-            @planar contractcheck=true C3[i; j] := A[i; k l] * τ[k l; m n] * B[n j; m]
+            @planar contractcheck = true C3[i; j] := A[i; k l] * τ[k l; m n] * B[n j; m]
         end
     end
-    
+
     @testset "MPS networks" begin
         P = ℂ^2
         Vmps = ℂ^12
@@ -171,14 +171,14 @@ end
         end
         @test C ≈ C′
     end
-    
+
     @testset "Issue 93" begin
         T = Float64
         V1 = ℂ^2
         V2 = ℂ^3
         t1 = TensorMap(rand, T, V1 ← V2)
         t2 = TensorMap(rand, T, V2 ← V1)
-        
+
         tr1 = @planar opt = true t1[a; b] * t2[b; a]
         tr2 = @planar opt = true t1[d; a] * t2[b; c] * τ[c b; a d]
         tr3 = @planar opt = true t1[d; a] * t2[b; c] * τ[a c; d b]
@@ -186,7 +186,7 @@ end
         tr5 = @planar opt = true t1[f; a] * t2[c; d] * τ[d b; c e] * τ[a e; f b]
         tr6 = @planar opt = true t1[f; a] * t2[c; d] * τ[c d; e b] * τ[e b; a f]
         tr7 = @planar opt = true t1[f; a] * t2[c; d] * τ[c d; e b] * τ[a e; f b]
-        
+
         @test tr1 ≈ tr2 ≈ tr3 ≈ tr4 ≈ tr5 ≈ tr6 ≈ tr7
     end
 end

--- a/test/planar.jl
+++ b/test/planar.jl
@@ -171,4 +171,22 @@ end
         end
         @test C ≈ C′
     end
+    
+    @testset "Issue 93" begin
+        T = Float64
+        V1 = ℂ^2
+        V2 = ℂ^3
+        t1 = TensorMap(rand, T, V1 ← V2)
+        t2 = TensorMap(rand, T, V2 ← V1)
+        
+        tr1 = @planar opt = true t1[a; b] * t2[b; a]
+        tr2 = @planar opt = true t1[d; a] * t2[b; c] * τ[c b; a d]
+        tr3 = @planar opt = true t1[d; a] * t2[b; c] * τ[a c; d b]
+        tr4 = @planar opt = true t1[f; a] * t2[c; d] * τ[d b; c e] * τ[e b; a f]
+        tr5 = @planar opt = true t1[f; a] * t2[c; d] * τ[d b; c e] * τ[a e; f b]
+        tr6 = @planar opt = true t1[f; a] * t2[c; d] * τ[c d; e b] * τ[e b; a f]
+        tr7 = @planar opt = true t1[f; a] * t2[c; d] * τ[c d; e b] * τ[a e; f b]
+        
+        @test tr1 ≈ tr2 ≈ tr3 ≈ tr4 ≈ tr5 ≈ tr6 ≈ tr7
+    end
 end

--- a/test/planar.jl
+++ b/test/planar.jl
@@ -140,6 +140,23 @@ end
                                   conj(x′[1 3; -1])
         @test force_planar(ρ2) ≈ ρ2′
         @test ρ2 ≈ ρ3
+
+        # Periodic boundary conditions
+        # ----------------------------
+        f1 = isomorphism(storagetype(O), fuse(Vmpo^3), Vmpo ⊗ Vmpo' ⊗ Vmpo)
+        f2 = isomorphism(storagetype(O), fuse(Vmpo^3), Vmpo ⊗ Vmpo' ⊗ Vmpo)
+        f1′ = force_planar(f1)
+        f2′ = force_planar(f2)
+        @tensor O_periodic1[-1 -2; -3 -4] := O[1 -2; -3 2] * f1[-1; 1 3 4] *
+                                             conj(f2[-4; 2 3 4])
+        @plansor O_periodic2[-1 -2; -3 -4] := O[1 2; -3 6] * f1[-1; 1 3 5] *
+                                              conj(f2[-4; 6 7 8]) * τ[2 3; 7 4] *
+                                              τ[4 5; 8 -2]
+        @planar O_periodic′[-1 -2; -3 -4] := O′[1 2; -3 6] * f1′[-1; 1 3 5] *
+                                             conj(f2′[-4; 6 7 8]) * τ[2 3; 7 4] *
+                                             τ[4 5; 8 -2]
+        @test O_periodic1 ≈ O_periodic2
+        @test force_planar(O_periodic1) ≈ O_periodic′
     end
 
     @testset "MERA networks" begin


### PR DESCRIPTION
Previously, this constructed an indexmap, but this is ambiguous if an index appears on multiple braidingtensors.
This should now be fixed by contructing braidingtensors independently. 
Also adds a test for the case that was not caught.
Fixes #93