### PR TITLE
add multi-threading support for mul!, add! and tsvd!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 __pycache__
 .ipynb*
 Manifest.toml
+.vscode
+dev


### PR DESCRIPTION
I modified 3 methods `mul!`, `add!` and `_compute_svddata!` by adding a keyword argument `numthreads::Int64` to support multi-threading parallel computation. The behaviors will not change if `numthreads == 1`.

I did some benchmark tests. The behaviors are different between `openblas`(julia's default) and `mkl`(using MKL with an intel's cpu) as backend . 
 - openblas: nested multi-threading (i.e. both distributing sectors and using multi-threading BLAS functions) seems to be forbidden by julia. Nevertheless,  parallelizing sectors or basic BLAS operations share similar performance.
 - mkl: nested multi-threading is supported, which significantly accelerates the computation when using enough cpu cores.
 
Note added: I found parallelized `add!` seems to exhibit worse performance, since it is not expansive enough compared with the multi-threading overhead, just a guess. Therefore, I set the default `numthreads == 1` specially. 