### PR TITLE
Some docs fixes

### DIFF
--- a/docs/src/lib/sectors.md
+++ b/docs/src/lib/sectors.md
@@ -37,7 +37,7 @@ Rsymbol
 Bsymbol
 dim(::Sector)
 frobeniusschur
-twist
+twist(::Sector)
 Base.isreal(::Type{<:Sector})
 TensorKit.vertex_labeltype
 TensorKit.vertex_ind2label
@@ -69,7 +69,8 @@ foldleft
 cycleclockwise
 cycleanticlockwise
 repartition
-transpose
+transpose(f₁::FusionTree{I}, f₂::FusionTree{I},
+                        p1::IndexTuple{N₁}, p2::IndexTuple{N₂}) where {I<:Sector,N₁,N₂}
 braid(f₁::FusionTree{I}, f₂::FusionTree{I}, levels1::IndexTuple, levels2::IndexTuple, p1::IndexTuple{N₁}, p2::IndexTuple{N₂}) where {I<:Sector,N₁,N₂}
 permute(f₁::FusionTree{I}, f₂::FusionTree{I}, p1::IndexTuple{N₁}, p2::IndexTuple{N₂}) where {I<:Sector,N₁,N₂}
 ```

--- a/docs/src/lib/spaces.md
+++ b/docs/src/lib/spaces.md
@@ -62,7 +62,7 @@ while the following also work on both `ElementarySpace` and `ProductSpace`
 ```@docs
 fuse
 :⊗
-:⊠
+⊠(::VectorSpace, ::VectorSpace)
 one
 ismonomorphic
 isepimorphic

--- a/docs/src/lib/spaces.md
+++ b/docs/src/lib/spaces.md
@@ -40,7 +40,8 @@ sectors
 hassector
 dim
 dims
-blocksectors
+blocksectors(::ProductSpace)
+blocksectors(::HomSpace)
 blockdim
 space
 ```

--- a/docs/src/lib/tensors.md
+++ b/docs/src/lib/tensors.md
@@ -10,7 +10,6 @@ The type hierarchy of tensors is as follows:
 
 ```@docs
 AbstractTensorMap
-AbstractTensor
 TensorMap
 AdjointTensorMap
 BraidingTensor
@@ -48,7 +47,7 @@ The following methods exist to obtain type information:
 
 ```@docs
 spacetype
-sectortype
+sectortype(::Type{<:AbstractTensorMap{S}}) where {S<:IndexSpace}
 storagetype
 tensormaptype
 ```
@@ -57,7 +56,7 @@ To obtain information about the indices, you can use:
 ```@docs
 domain
 codomain
-space
+space(::AbstractTensorMap)
 numin
 numout
 numind
@@ -68,8 +67,8 @@ allind
 
 To obtain information about the data, the following methods exist:
 ```@docs
-blocksectors
-blockdim
+blocksectors(::AbstractTensorMap)
+blockdim(::AbstractTensorMap, ::Sector)
 block
 blocks
 fusiontrees
@@ -92,8 +91,8 @@ scaling, as well as the selection of a custom backend.
 ```@docs
 permute(t::AbstractTensorMap{S}, (p₁, p₂)::Index2Tuple{N₁,N₂}; copy::Bool=false) where {S,N₁,N₂}
 braid(t::AbstractTensorMap{S}, (p₁, p₂)::Index2Tuple, levels::IndexTuple; copy::Bool=false) where {S}
-transpose
-twist
+transpose(::AbstractTensorMap, ::Index2Tuple)
+twist(::AbstractTensorMap, ::Int)
 ```
 ```@docs
 permute!(tdst::AbstractTensorMap{S,N₁,N₂}, tsrc::AbstractTensorMap{S}, p::Index2Tuple{N₁,N₂}) where {S,N₁,N₂}

--- a/src/sectors/product.jl
+++ b/src/sectors/product.jl
@@ -180,7 +180,7 @@ const deligneproduct = ⊠
     deligneproduct(s₁::Sector, s₂::Sector)
 
 Given two sectors `s₁` and `s₂`, which label an isomorphism class of simple objects in a
-fusion category ``C₁`` and ``C₂``, `s1 ⊠ s2` (obtained as `\boxtimes+TAB`) labels the
+fusion category ``C₁`` and ``C₂``, `s1 ⊠ s2` (obtained as `\\boxtimes+TAB`) labels the
 isomorphism class of simple objects in the Deligne tensor product category ``C₁ ⊠ C₂``.
 
 The Deligne tensor product also works in the type domain and for spaces and tensors. For

--- a/src/tensors/abstracttensor.jl
+++ b/src/tensors/abstracttensor.jl
@@ -211,13 +211,13 @@ hasblock
     blocksectors(t::AbstractTensorMap)
 
 Return an iterator over all coupled sectors of a tensor.
-""" blocksectors
+""" blocksectors(::AbstractTensorMap)
 
 @doc """
     blockdim(t::AbstractTensorMap, c::Sector) -> Base.Dims
 
 Return the dimensions of the block of a tensor corresponding to a coupled sector `c`.
-""" blockdim
+""" blockdim(::AbstractTensorMap, ::Sector)
 
 @doc """
     fusiontrees(t::AbstractTensorMap)

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -37,7 +37,7 @@ end
 #! format: on
 
 """
-    Tensor{S<:IndexSpace, N, I<:Sector, A, F₁, F₂} = TensorMap{S, N, 0, I, A, F₁, F₂}
+    Tensor{S, N, I, A, F₁, F₂} = TensorMap{S, N, 0, I, A, F₁, F₂}
 
 Specific subtype of [`AbstractTensor`](@ref) for representing tensors whose data is stored
 in blocks of some subtype of `DenseMatrix`.
@@ -45,7 +45,7 @@ in blocks of some subtype of `DenseMatrix`.
 A `Tensor{S, N, I, A, F₁, F₂}` is actually a special case `TensorMap{S, N, 0, I, A, F₁, F₂}`,
 i.e. a tensor map with only a non-trivial output space.
 """
-const Tensor{S<:IndexSpace,N,I<:Sector,A,F₁,F₂} = TensorMap{S,N,0,I,A,F₁,F₂}
+const Tensor{S,N,I,A,F₁,F₂} = TensorMap{S,N,0,I,A,F₁,F₂}
 """
     TrivialTensorMap{S<:IndexSpace, N₁, N₂, A<:DenseMatrix} = TensorMap{S, N₁, N₂, Trivial, 
                                                                         A, Nothing, Nothing}
@@ -53,15 +53,15 @@ const Tensor{S<:IndexSpace,N,I<:Sector,A,F₁,F₂} = TensorMap{S,N,0,I,A,F₁,F
 A special case of [`TensorMap`](@ref) for representing tensor maps with trivial symmetry,
 i.e., whose `sectortype` is `Trivial`.
 """
-const TrivialTensorMap{S<:IndexSpace,N₁,N₂,A<:DenseMatrix} = TensorMap{S,N₁,N₂,Trivial,A,
+const TrivialTensorMap{S,N₁,N₂,A<:DenseMatrix} = TensorMap{S,N₁,N₂,Trivial,A,
                                                                        Nothing,Nothing}
 """
-    TrivialTensor{S<:IndexSpace, N, A<:DenseMatrix} = TrivialTensorMap{S, N, 0, A}
+    TrivialTensor{S, N, A} = TrivialTensorMap{S, N, 0, A}
 
 A special case of [`Tensor`](@ref) for representing tensors with trivial symmetry, i.e.,
 whose `sectortype` is `Trivial`.
 """
-const TrivialTensor{S<:IndexSpace,N,A<:DenseMatrix} = TrivialTensorMap{S,N,0,A}
+const TrivialTensor{S,N,A} = TrivialTensorMap{S,N,0,A}
 """
     tensormaptype(::Type{S}, N₁::Int, N₂::Int, [::Type{T}]) where {S<:IndexSpace,T} -> ::Type{<:TensorMap}
 

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -36,9 +36,32 @@ struct TensorMap{S<:IndexSpace, N₁, N₂, I<:Sector, A<:Union{<:DenseMatrix,Se
 end
 #! format: on
 
+"""
+    Tensor{S<:IndexSpace, N, I<:Sector, A, F₁, F₂} = TensorMap{S, N, 0, I, A, F₁, F₂}
+
+Specific subtype of [`AbstractTensor`](@ref) for representing tensors whose data is stored
+in blocks of some subtype of `DenseMatrix`.
+
+A `Tensor{S, N, I, A, F₁, F₂}` is actually a special case `TensorMap{S, N, 0, I, A, F₁, F₂}`,
+i.e. a tensor map with only a non-trivial output space.
+"""
 const Tensor{S<:IndexSpace,N,I<:Sector,A,F₁,F₂} = TensorMap{S,N,0,I,A,F₁,F₂}
+"""
+    TrivialTensorMap{S<:IndexSpace, N₁, N₂, A<:DenseMatrix} = TensorMap{S, N₁, N₂, Trivial, 
+                                                                        A, Nothing, Nothing}
+
+A special case of [`TensorMap`](@ref) for representing tensor maps with trivial symmetry,
+i.e., whose `sectortype` is `Trivial`.
+"""
 const TrivialTensorMap{S<:IndexSpace,N₁,N₂,A<:DenseMatrix} = TensorMap{S,N₁,N₂,Trivial,A,
                                                                        Nothing,Nothing}
+"""
+    TrivialTensor{S<:IndexSpace, N, I<:Sector, A, F₁, F₂} = TrivialTensorMap{S, N, 0, A}
+
+A special case of [`Tensor`](@ref) for representing tensors with trivial symmetry, i.e.,
+whose `sectortype` is `Trivial`.
+"""
+const TrivialTensor{S<:IndexSpace,N,A<:DenseMatrix} = TrivialTensorMap{S,N,0,A}
 """
     tensormaptype(::Type{S}, N₁::Int, N₂::Int, [::Type{T}]) where {S<:IndexSpace,T} -> ::Type{<:TensorMap}
 
@@ -72,6 +95,11 @@ domain(t::TensorMap) = t.dom
 blocksectors(t::TrivialTensorMap) = OneOrNoneIterator(dim(t) != 0, Trivial())
 blocksectors(t::TensorMap) = keys(t.data)
 
+"""
+    storagetype(::Union{T,Type{T}}) where {T<:TensorMap} -> Type{A<:DenseMatrix}
+
+Return the type of the storage `A` of the tensor map.
+"""
 function storagetype(::Type{<:TensorMap{<:IndexSpace,N₁,N₂,Trivial,A}}) where
          {N₁,N₂,A<:DenseMatrix}
     return A

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -56,7 +56,7 @@ i.e., whose `sectortype` is `Trivial`.
 const TrivialTensorMap{S<:IndexSpace,N₁,N₂,A<:DenseMatrix} = TensorMap{S,N₁,N₂,Trivial,A,
                                                                        Nothing,Nothing}
 """
-    TrivialTensor{S<:IndexSpace, N, I<:Sector, A, F₁, F₂} = TrivialTensorMap{S, N, 0, A}
+    TrivialTensor{S<:IndexSpace, N, A<:DenseMatrix} = TrivialTensorMap{S, N, 0, A}
 
 A special case of [`Tensor`](@ref) for representing tensors with trivial symmetry, i.e.,
 whose `sectortype` is `Trivial`.

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -54,7 +54,7 @@ A special case of [`TensorMap`](@ref) for representing tensor maps with trivial 
 i.e., whose `sectortype` is `Trivial`.
 """
 const TrivialTensorMap{S,N₁,N₂,A<:DenseMatrix} = TensorMap{S,N₁,N₂,Trivial,A,
-                                                                       Nothing,Nothing}
+                                                           Nothing,Nothing}
 """
     TrivialTensor{S, N, A} = TrivialTensorMap{S, N, 0, A}
 


### PR DESCRIPTION
Some fixes for docstrings that appeared as missing in `lib/tensors`. Some of them were actually missing and I only added the ones I was confident about adding, and some of them weren't appearing because they were already referenced somewhere else so I had to mess with the type specifiers a bit.

The only thing here I'm not too sure about are the references to `blocksectors` in `lib/spaces`. I found two relevant documented methods so I added these both explicitly, but it feels like maybe there should just be one docstring for an overarching `blocksectors(::VectorSpace)`?