### PR TITLE
Add unicode alternatives: `otimes` and `oplus`

### DIFF
--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -37,7 +37,7 @@ export infimum, supremum, isisomorphic, ismonomorphic, isepimorphic
 
 # methods for sectors and properties thereof
 export sectortype, sectors, hassector, Nsymbol, Fsymbol, Rsymbol, Bsymbol,
-       frobeniusschur, twist
+       frobeniusschur, twist, otimes
 export fusiontrees, braid, permute, transpose
 export ZNSpace, SU2Irrep, U1Irrep, CU1Irrep
 # other fusion tree manipulations, should not be exported:

--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -30,7 +30,7 @@ export TruncationScheme
 export SpaceMismatch, SectorMismatch, IndexError # error types
 
 # general vector space methods
-export space, field, dual, dim, dims, fuse, flip, isdual, insertunit
+export space, field, dual, dim, dims, fuse, flip, isdual, insertunit, oplus
 
 # partial order for vector spaces
 export infimum, supremum, isisomorphic, ismonomorphic, isepimorphic

--- a/src/sectors/sectors.jl
+++ b/src/sectors/sectors.jl
@@ -119,7 +119,8 @@ Base.isless(::Trivial, ::Trivial) = false
 # FusionStyle: the most important aspect of Sector
 #---------------------------------------------
 """
-    ⊗(a::I, b::I) where {I<:Sector}
+    ⊗(a::I, b::I...) where {I<:Sector}
+    otimes(a::I, b::I...) where {I<:Sector}
 
 Return an iterable of elements of `c::I` that appear in the fusion product `a ⊗ b`.
 
@@ -128,6 +129,7 @@ Note that every element `c` should appear at most once, fusion degeneracies (if
 """
 ⊗(::Trivial, ::Trivial) = (Trivial(),)
 ⊗(I::Sector) = (I,)
+const otimes = ⊗
 
 """
     Nsymbol(a::I, b::I, c::I) where {I<:Sector} -> Integer

--- a/src/spaces/vectorspaces.jl
+++ b/src/spaces/vectorspaces.jl
@@ -123,6 +123,7 @@ Base.oneunit(V::ElementarySpace) = oneunit(typeof(V))
 
 """
     ⊕(V₁::S, V₂::S, V₃::S...) where {S<:ElementarySpace} -> S
+    oplus(V₁::S, V₂::S, V₃::S...) where {S<:ElementarySpace} -> S
 
 Return the corresponding vector space of type `S` that represents the direct sum sum of the
 spaces `V₁`, `V₂`, ... Note that all the individual spaces should have the same value for
@@ -131,6 +132,7 @@ spaces `V₁`, `V₂`, ... Note that all the individual spaces should have the s
 function ⊕ end
 ⊕(V₁::VectorSpace, V₂::VectorSpace) = ⊕(promote(V₁, V₂)...)
 ⊕(V::Vararg{VectorSpace}) = foldl(⊕, V)
+const oplus = ⊕
 
 """
     ⊗(V₁::S, V₂::S, V₃::S...) where {S<:ElementarySpace} -> S

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -423,6 +423,7 @@ end
 # tensor product of tensors
 """
     ⊗(t1::AbstractTensorMap{S}, t2::AbstractTensorMap{S}, ...) -> TensorMap{S}
+    otimes(t1::AbstractTensorMap{S}, t2::AbstractTensorMap{S}, ...) -> TensorMap{S}
 
 Compute the tensor product between two `AbstractTensorMap` instances, which results in a
 new `TensorMap` instance whose codomain is `codomain(t1) ⊗ codomain(t2)` and whose domain


### PR DESCRIPTION
Adds a non-unicode alternative to `\otimes` for sectors: `fusionproduct`.

Fixes #108 .