### PR TITLE
Update postprocessors.jl

### DIFF
--- a/src/planar/postprocessors.jl
+++ b/src/planar/postprocessors.jl
@@ -5,7 +5,8 @@
 # to correct for this by adding the `istemp = true` flag.
 function _annotate_temporaries(ex, temporaries)
     if isexpr(ex, :(=)) && isexpr(ex.args[2], :call) &&
-       ex.args[2].args[1] ∈ (GlobalRef(TO,:tensoralloc_add), GlobalRef(TO,:tensoralloc_contract))
+       ex.args[2].args[1] ∈
+       (GlobalRef(TO, :tensoralloc_add), GlobalRef(TO, :tensoralloc_contract))
         lhs = ex.args[1]
         i = findfirst(==(lhs), temporaries)
         if i !== nothing

--- a/src/planar/postprocessors.jl
+++ b/src/planar/postprocessors.jl
@@ -5,7 +5,7 @@
 # to correct for this by adding the `istemp = true` flag.
 function _annotate_temporaries(ex, temporaries)
     if isexpr(ex, :(=)) && isexpr(ex.args[2], :call) &&
-       ex.args[2].args[1] ∈ (:tensoralloc_add, :tensoralloc_contract)
+       ex.args[2].args[1] ∈ (GlobalRef(TO,:tensoralloc_add), GlobalRef(TO,:tensoralloc_contract))
         lhs = ex.args[1]
         i = findfirst(==(lhs), temporaries)
         if i !== nothing


### PR DESCRIPTION
before:
```
julia> @macroexpand (@planar allocator=malloc out[-1 -2 -3;-4 -5] := l[-1 1;-4]*o[1 -2;-5 -3])
quote
    numout(l) == 2 && numin(l) == 1 || throw(TensorOperations.IndexError("Incorrect number of input-output indices for l: (2, 1) instead of ($((numout(l), numin(l))))."))
    numout(o) == 2 && numin(o) == 2 || throw(TensorOperations.IndexError("Incorrect number of input-output indices for o: (2, 2) instead of ($((numout(o), numin(o))))."))
    var"##T_##304#305" = TensorOperations.promote_contract(TensorOperations.scalartype(l), TensorOperations.scalartype(o))
    var"##304" = TensorOperations.tensoralloc_contract(var"##T_##304#305", ((2, 1), (4, 5, 3)), l, ((1, 3), (2,)), :N, o, ((1,), (2, 3, 4)), :N, false, TensorOperations.Backend{:malloc}())
    var"##304" = TensorKit._planarcontract!(var"##304", ((2, 1), (4, 5, 3)), l, ((1, 3), (2,)), o, ((1,), (2, 3, 4)), VectorInterface.One(), VectorInterface.Zero())
    var"##T_out#306" = TensorOperations.scalartype(var"##304")
    out = TensorOperations.tensoralloc_add(var"##T_out#306", ((2, 5, 4), (1, 3)), var"##304", :N, false, TensorOperations.Backend{:malloc}())
    out = TensorKit._planaradd!(out, ((2, 5, 4), (1, 3)), var"##304", VectorInterface.One(), VectorInterface.Zero())
    TensorOperations.tensorfree!(var"##304", TensorOperations.Backend{:malloc}())
    out
end

```

Now it correctly labels var"##304" as a temporary, and no longer segfaults.