### PR TITLE
Specify eltype for CU1Irrep product iterator

### DIFF
--- a/src/sectors/irreps.jl
+++ b/src/sectors/irreps.jl
@@ -334,6 +334,7 @@ function Base.length(p::CU1ProdIterator)
         return 2
     end
 end
+Base.eltype(::Type{CU1ProdIterator}) = CU1Irrep
 
 ⊗(a::CU1Irrep, b::CU1Irrep) = CU1ProdIterator(a, b)
 

--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -20,6 +20,7 @@ println("------------------------------------")
             @constinferred Fsymbol(s..., s...)
             it = @constinferred s[1] ⊗ s[2]
             @test eltype(it) === I
+            @test collect(it) isa Array{I}
             @constinferred ⊗(s..., s...)
         end
         @testset "Sector $Istr: Value iterator" begin

--- a/test/sectors.jl
+++ b/test/sectors.jl
@@ -19,6 +19,7 @@ println("------------------------------------")
             @constinferred Bsymbol(s...)
             @constinferred Fsymbol(s..., s...)
             it = @constinferred s[1] ⊗ s[2]
+            @test eltype(it) === I
             @constinferred ⊗(s..., s...)
         end
         @testset "Sector $Istr: Value iterator" begin


### PR DESCRIPTION
I am not sure if this actually has some performance implications in the code, but at the very least it changes the following:
Before:
```julia-repl
julia> collect(CU1Irrep(0) ⊗ CU1Irrep(1))
1-element Vector{Any}:
 Irrep[CU₁](1, 2)
```
---
After:
```julia-repl
julia> collect(CU1Irrep(0) ⊗ CU1Irrep(1))
1-element Vector{CU1Irrep}:
 (1, 2)
```
