### PR TITLE
Utility and Quality of life for VectorSpaces

### DIFF
--- a/src/spaces/cartesianspace.jl
+++ b/src/spaces/cartesianspace.jl
@@ -27,6 +27,7 @@ function CartesianSpace(dims::AbstractDict; kwargs...)
         throw(SectorMismatch(msg))
     end
 end
+CartesianSpace(g::Base.Generator; kwargs...) = CartesianSpace(g...; kwargs...)
 
 field(::Type{CartesianSpace}) = ℝ
 InnerProductStyle(::Type{CartesianSpace}) = EuclideanProduct()

--- a/src/spaces/complexspace.jl
+++ b/src/spaces/complexspace.jl
@@ -28,6 +28,7 @@ function ComplexSpace(dims::AbstractDict; kwargs...)
         throw(SectorMismatch(msg))
     end
 end
+ComplexSpace(g::Base.Generator; kwargs...) = ComplexSpace(g...; kwargs...)
 
 field(::Type{ComplexSpace}) = ℂ
 InnerProductStyle(::Type{ComplexSpace}) = EuclideanProduct()

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -115,3 +115,16 @@ function dim(W::HomSpace)
     end
     return d
 end
+
+# Operations on HomSpaces
+# -----------------------
+function permute(W::HomSpace{S}, (p₁, p₂)::Index2Tuple{N₁,N₂}) where {S,N₁,N₂}
+    cod = ProductSpace{S,N₁}(map(n -> W[n], p₁))
+    dom = ProductSpace{S,N₂}(map(n -> dual(W[n]), p₂))
+    return cod ← dom
+end
+
+function Base.:*(W::HomSpace{S}, V::HomSpace{S}) where {S}
+    domain(W) == codomain(V) || throw(SpaceMismatch("$(domain(W)) ≠ $(codomain(V))"))
+    return HomSpace(codomain(W), domain(V))
+end

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -124,7 +124,13 @@ function permute(W::HomSpace{S}, (p₁, p₂)::Index2Tuple{N₁,N₂}) where {S,
     return cod ← dom
 end
 
-function Base.:*(W::HomSpace{S}, V::HomSpace{S}) where {S}
+"""
+    compose(W::HomSpace, V::HomSpace)
+
+Obtain the HomSpace that is obtained from composing the morphisms in `W` and `V`. For this
+to be possible, the domain of `W` must match the codomain of `V`.
+"""
+function compose(W::HomSpace{S}, V::HomSpace{S}) where {S}
     domain(W) == codomain(V) || throw(SpaceMismatch("$(domain(W)) ≠ $(codomain(V))"))
     return HomSpace(codomain(W), domain(V))
 end

--- a/src/spaces/vectorspaces.jl
+++ b/src/spaces/vectorspaces.jl
@@ -160,6 +160,7 @@ individual spaces `V₁`, `V₂`, ..., or the spaces contained in `P`.
 """
 function fuse end
 fuse(V::ElementarySpace) = isdual(V) ? flip(V) : V
+fuse(V::ElementarySpace, W::ElementarySpace) = fuse(promote(V, W)...)
 function fuse(V₁::VectorSpace, V₂::VectorSpace, V₃::VectorSpace...)
     return fuse(fuse(fuse(V₁), fuse(V₂)), V₃...)
 end

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -320,14 +320,11 @@ function add_transform!(tdst::AbstractTensorMap{S,N₁,N₂},
     if p₁ == codomainind(tsrc) && p₂ == domainind(tsrc)
         add!(tdst, tsrc, α, β)
     elseif I === Trivial
-        _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
-                                       backend...)
+        _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
     elseif FusionStyle(I) isa UniqueFusion
-        _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
-                                       backend...)
+        _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
     else
-        _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
-                                       backend...)
+        _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
     end
     return tdst
 end
@@ -373,8 +370,8 @@ function _add_general_kernel!(tdst, tsrc, p, fusiontreetransform, α, β, backen
     else
         for (f₁, f₂) in fusiontrees(tsrc)
             for ((f₁′, f₂′), coeff) in fusiontreetransform(f₁, f₂)
-                @inbounds TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, true,
-                              backend...)
+                @inbounds TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff,
+                                        true, backend...)
             end
         end
     end
@@ -386,7 +383,8 @@ function _add_nonabelian_sector!(tdst, tsrc, p, fusiontreetransform, s₁, s₂,
     for (f₁, f₂) in fusiontrees(tsrc)
         (f₁.uncoupled == s₁ && f₂.uncoupled == s₂) || continue
         for ((f₁′, f₂′), coeff) in fusiontreetransform(f₁, f₂)
-            @inbounds TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, true, backend...)
+            @inbounds TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, true,
+                                    backend...)
         end
     end
     return nothing

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -318,15 +318,15 @@ function add_transform!(tdst::AbstractTensorMap{S,N₁,N₂},
 
     I = sectortype(S)
     if p₁ == codomainind(tsrc) && p₂ == domainind(tsrc)
-        @inbounds add!(tdst, tsrc, α, β)
+        add!(tdst, tsrc, α, β)
     elseif I === Trivial
-        @inbounds _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
+        _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
                                        backend...)
     elseif FusionStyle(I) isa UniqueFusion
-        @inbounds _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
+        _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
                                        backend...)
     else
-        @inbounds _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
+        _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
                                        backend...)
     end
     return tdst
@@ -355,7 +355,7 @@ end
 
 function _add_abelian_block!(tdst, tsrc, p, fusiontreetransform, f₁, f₂, α, β, backend...)
     (f₁′, f₂′), coeff = first(fusiontreetransform(f₁, f₂))
-    TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, β, backend...)
+    @inbounds TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, β, backend...)
     return nothing
 end
 
@@ -373,7 +373,7 @@ function _add_general_kernel!(tdst, tsrc, p, fusiontreetransform, α, β, backen
     else
         for (f₁, f₂) in fusiontrees(tsrc)
             for ((f₁′, f₂′), coeff) in fusiontreetransform(f₁, f₂)
-                TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, true,
+                @inbounds TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, true,
                               backend...)
             end
         end
@@ -386,7 +386,7 @@ function _add_nonabelian_sector!(tdst, tsrc, p, fusiontreetransform, s₁, s₂,
     for (f₁, f₂) in fusiontrees(tsrc)
         (f₁.uncoupled == s₁ && f₂.uncoupled == s₂) || continue
         for ((f₁′, f₂′), coeff) in fusiontreetransform(f₁, f₂)
-            TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, true, backend...)
+            @inbounds TO.tensoradd!(tdst[f₁′, f₂′], p, tsrc[f₁, f₂], :N, α * coeff, true, backend...)
         end
     end
     return nothing

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -320,11 +320,14 @@ function add_transform!(tdst::AbstractTensorMap{S,N₁,N₂},
     if p₁ == codomainind(tsrc) && p₂ == domainind(tsrc)
         @inbounds add!(tdst, tsrc, α, β)
     elseif I === Trivial
-        @inbounds _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
+        @inbounds _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
+                                       backend...)
     elseif FusionStyle(I) isa UniqueFusion
-        @inbounds _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
+        @inbounds _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
+                                       backend...)
     else
-        @inbounds _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
+        @inbounds _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β,
+                                       backend...)
     end
     return tdst
 end

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -30,19 +30,19 @@ To permute into an existing destination, see [permute!](@ref) and [`add_permute!
 """
 function permute(t::AbstractTensorMap{S}, (p₁, p₂)::Index2Tuple{N₁,N₂};
                  copy::Bool=false) where {S,N₁,N₂}
-    cod = ProductSpace{S,N₁}(map(n -> space(t, n), p₁))
-    dom = ProductSpace{S,N₂}(map(n -> dual(space(t, n)), p₂))
+    space′ = permute(space(t), (p₁, p₂))
     # share data if possible
     if !copy
         if p₁ === codomainind(t) && p₂ === domainind(t)
             return t
         elseif has_shared_permute(t, (p₁, p₂))
-            return TensorMap(reshape(t.data, dim(cod), dim(dom)), cod, dom)
+            return TensorMap(reshape(t.data, dim(codomain(space′)), dim(domain(space′))),
+                             codomain(space′), domain(space′))
         end
     end
     # general case
     @inbounds begin
-        return permute!(similar(t, cod ← dom), t, (p₁, p₂))
+        return permute!(similar(t, space′), t, (p₁, p₂))
     end
 end
 function permute(t::AdjointTensorMap{S}, (p₁, p₂)::Index2Tuple;
@@ -118,10 +118,9 @@ function braid(t::AbstractTensorMap{S}, (p₁, p₂)::Index2Tuple, levels::Index
         return t
     end
     # general case
-    cod = ProductSpace{S}(map(n -> space(t, n), p₁))
-    dom = ProductSpace{S}(map(n -> dual(space(t, n)), p₂))
+    space′ = permute(space(t), (p₁, p₂))
     @inbounds begin
-        return braid!(similar(t, cod ← dom), t, (p₁, p₂), levels)
+        return braid!(similar(t, space′), t, (p₁, p₂), levels)
     end
 end
 # TODO: braid for `AdjointTensorMap`; think about how to map the `levels` argument.
@@ -171,10 +170,9 @@ function LinearAlgebra.transpose(t::AbstractTensorMap{S},
         return t
     end
     # general case
-    cod = ProductSpace{S}(map(n -> space(t, n), p₁))
-    dom = ProductSpace{S}(map(n -> dual(space(t, n)), p₂))
+    space′ = permute(space(t), (p₁, p₂))
     @inbounds begin
-        return transpose!(similar(t, cod ← dom), t, (p₁, p₂))
+        return transpose!(similar(t, space′), t, (p₁, p₂))
     end
 end
 
@@ -313,23 +311,20 @@ function add_transform!(tdst::AbstractTensorMap{S,N₁,N₂},
                         β::Number,
                         backend::Backend...) where {S,N₁,N₂}
     @boundscheck begin
-        all(i -> space(tsrc, p₁[i]) == space(tdst, i), 1:N₁) ||
-            throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
-            dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
-        all(i -> space(tsrc, p₂[i]) == space(tdst, N₁ + i), 1:N₂) ||
+        permute(space(tsrc), (p₁, p₂)) == space(tdst) ||
             throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
             dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
     end
 
     I = sectortype(S)
     if p₁ == codomainind(tsrc) && p₂ == domainind(tsrc)
-        add!(tdst, tsrc, α, β)
+        @inbounds add!(tdst, tsrc, α, β)
     elseif I === Trivial
-        _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
+        @inbounds _add_trivial_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
     elseif FusionStyle(I) isa UniqueFusion
-        _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
+        @inbounds _add_abelian_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
     else
-        _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
+        @inbounds _add_general_kernel!(tdst, tsrc, (p₁, p₂), fusiontreetransform, α, β, backend...)
     end
     return tdst
 end

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -20,7 +20,7 @@ LinearAlgebra.normalize(t::AbstractTensorMap, p::Real=2) = scale(t, inv(norm(t, 
 
 function Base.:*(t1::AbstractTensorMap, t2::AbstractTensorMap)
     return mul!(similar(t1, promote_type(scalartype(t1), scalartype(t2)),
-                        codomain(t1) ← domain(t2)), t1, t2)
+                        space(t1) * space(t2)), t1, t2)
 end
 Base.exp(t::AbstractTensorMap) = exp!(copy(t))
 function Base.:^(t::AbstractTensorMap, p::Integer)
@@ -242,10 +242,9 @@ end
 function LinearAlgebra.mul!(tC::AbstractTensorMap,
                             tA::AbstractTensorMap,
                             tB::AbstractTensorMap, α=true, β=false)
-    if !(codomain(tC) == codomain(tA) && domain(tC) == domain(tB) &&
-         domain(tA) == codomain(tB))
+    space(tA) * space(tB) == space(tC) ||
         throw(SpaceMismatch("$(space(tC)) ≠ $(space(tA)) * $(space(tB))"))
-    end
+
     for c in blocksectors(tC)
         if hasblock(tA, c) # then also tB should have such a block
             A = block(tA, c)

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -20,7 +20,7 @@ LinearAlgebra.normalize(t::AbstractTensorMap, p::Real=2) = scale(t, inv(norm(t, 
 
 function Base.:*(t1::AbstractTensorMap, t2::AbstractTensorMap)
     return mul!(similar(t1, promote_type(scalartype(t1), scalartype(t2)),
-                        space(t1) * space(t2)), t1, t2)
+                        compose(space(t1), space(t2))), t1, t2)
 end
 Base.exp(t::AbstractTensorMap) = exp!(copy(t))
 function Base.:^(t::AbstractTensorMap, p::Integer)
@@ -242,7 +242,7 @@ end
 function LinearAlgebra.mul!(tC::AbstractTensorMap,
                             tA::AbstractTensorMap,
                             tB::AbstractTensorMap, α=true, β=false)
-    space(tA) * space(tB) == space(tC) ||
+    compose(space(tA), space(tB)) == space(tC) ||
         throw(SpaceMismatch("$(space(tC)) ≠ $(space(tA)) * $(space(tB))"))
 
     for c in blocksectors(tC)

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -18,10 +18,18 @@ Base.:\(α::Number, t::AbstractTensorMap) = *(t, one(scalartype(t)) / α)
 LinearAlgebra.normalize!(t::AbstractTensorMap, p::Real=2) = scale!(t, inv(norm(t, p)))
 LinearAlgebra.normalize(t::AbstractTensorMap, p::Real=2) = scale(t, inv(norm(t, p)))
 
-function Base.:*(t1::AbstractTensorMap, t2::AbstractTensorMap)
+"""
+    compose(t1::AbstractTensorMap, t2::AbstractTensorMap) -> AbstractTensorMap
+
+Return the `AbstractTensorMap` that implements the composition of the two tensor maps `t1`
+and `t2`.
+"""
+function compose(t1::AbstractTensorMap, t2::AbstractTensorMap)
     return mul!(similar(t1, promote_type(scalartype(t1), scalartype(t2)),
                         compose(space(t1), space(t2))), t1, t2)
 end
+Base.:*(t1::AbstractTensorMap, t2::AbstractTensorMap) = compose(t1, t2)
+
 Base.exp(t::AbstractTensorMap) = exp!(copy(t))
 function Base.:^(t::AbstractTensorMap, p::Integer)
     return p < 0 ? Base.power_by_squaring(inv(t), -p) : Base.power_by_squaring(t, p)

--- a/src/tensors/tensoroperations.jl
+++ b/src/tensors/tensoroperations.jl
@@ -128,7 +128,7 @@ function TO.tensorcontract_structure(pC::Index2Tuple{N₁,N₂},
                                      conjB) where {S,N₁,N₂}
     sA = TO.tensoradd_structure(pA, A, conjA)
     sB = TO.tensoradd_structure(pB, B, conjB)
-    return permute(sA * sB, pC)
+    return permute(compose(sA, sB), pC)
 end
 
 function TO.checkcontractible(tA::AbstractTensorMap{S}, iA::Int, conjA::Symbol,

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -412,6 +412,6 @@ println("------------------------------------")
         @test W == deepcopy(W)
         @test W == @constinferred permute(W, ((1, 2), (3, 4, 5)))
         @test permute(W, ((2, 4, 5), (3, 1))) == (V2 ⊗ V4' ⊗ V5' ← V3 ⊗ V1')
-        @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred compose(W, W')
+        @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred TensorKit.compose(W, W')
     end
 end

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -410,5 +410,8 @@ println("------------------------------------")
         @test W[5] == V5'
         @test @constinferred(hash(W)) == hash(deepcopy(W)) != hash(W')
         @test W == deepcopy(W)
+        @test W == @constinferred permute(W, ((1, 2), (3, 4, 5)))
+        @test permute(W, ((2, 4, 5), (3, 1))) == (V2 ⊗ V4' ⊗ V5' ← V3 ⊗ V1')
+        @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred W * W'
     end
 end

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -412,6 +412,6 @@ println("------------------------------------")
         @test W == deepcopy(W)
         @test W == @constinferred permute(W, ((1, 2), (3, 4, 5)))
         @test permute(W, ((2, 4, 5), (3, 1))) == (V2 ⊗ V4' ⊗ V5' ← V3 ⊗ V1')
-        @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred W * W'
+        @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred compose(W, W')
     end
 end


### PR DESCRIPTION
This PR adds some missing constructors for ComplexSpace and CartesianSpace with generators, and refactors some small pieces of code that were being used for permuting and manipulating spaces to be in one place.

Additionally, it cleans up some of the space checks, and adds missing `@inbounds`  annotations for the `add_***_kernels`, which avoids a couple hash calls in the `getindex` for the fusion trees I think.