### PR TITLE
Add support for `eigvals`, `svdvals` and `diag`, `diagm`.

### DIFF
--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -182,12 +182,13 @@ function LinearAlgebra.eigvals(t::AbstractTensorMap; kwargs...)
     return LinearAlgebra.eigvals!(copy(t); kwargs...)
 end
 function LinearAlgebra.eigvals!(t::AbstractTensorMap; kwargs...)
-    return SectorDict(c => LinearAlgebra.eigvals!(b; kwargs...) for (c, b) in blocks(t))
+    return SectorDict(c => complex(LinearAlgebra.eigvals!(b; kwargs...))
+                      for (c, b) in blocks(t))
 end
 
 # TODO: decide if we want to keep these specializations:
 function LinearAlgebra.eigvals!(t::TrivialTensorMap; kwargs...)
-    return LinearAlgebra.eigvals!(t.data; kwargs...)
+    return complex(LinearAlgebra.eigvals!(t.data; kwargs...))
 end
 
 """

--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -190,28 +190,6 @@ function LinearAlgebra.eigvals!(t::TrivialTensorMap; kwargs...)
     return LinearAlgebra.eigvals!(t.data; kwargs...)
 end
 
-function LinearAlgebra.eigvecs(t::AbstractTensorMap; kwargs...)
-    InnerProductStyle(t) === EuclideanProduct() || throw_invalid_innerproduct(:eigvecs)
-    domain(t) == codomain(t) ||
-        throw(SpaceMismatch("`eigvecs` requires domain and codomain to be the same"))
-    S = spacetype(t)
-    I = sectortype(t)
-    A = storagetype(t)
-    Vdata = SectorDict{I,A}()
-    dims = SectorDict{I,Int}()
-    for (c, b) in blocks(t)
-        vectors = LinearAlgebra.eigvecs(b; kwargs...)
-        Vdata[c] = vectors
-        dims[c] = size(vectors, 2)
-    end
-    if length(domain(t)) == 1
-        W = domain(t)[1]
-    else
-        W = S(dims)
-    end
-    return TensorMap(Vdata, domain(t) ← W)
-end
-
 """
     eig(t::AbstractTensor, (leftind, rightind)::Index2Tuple; kwargs...) -> D, V
 

--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -41,11 +41,6 @@ function LinearAlgebra.svdvals!(t::AbstractTensorMap)
     return SectorDict(c => LinearAlgebra.svdvals!(b) for (c, b) in blocks(t))
 end
 
-# TODO: decide if we want to keep these specializations:
-function LinearAlgebra.svdvals!(t::TrivialTensorMap)
-    return LinearAlgebra.svdvals!(t.data)
-end
-
 """
     leftorth(t::AbstractTensorMap, (leftind, rightind)::Index2Tuple;
                 alg::OrthogonalFactorizationAlgorithm = QRpos()) -> Q, R
@@ -184,11 +179,6 @@ end
 function LinearAlgebra.eigvals!(t::AbstractTensorMap; kwargs...)
     return SectorDict(c => complex(LinearAlgebra.eigvals!(b; kwargs...))
                       for (c, b) in blocks(t))
-end
-
-# TODO: decide if we want to keep these specializations:
-function LinearAlgebra.eigvals!(t::TrivialTensorMap; kwargs...)
-    return complex(LinearAlgebra.eigvals!(t.data; kwargs...))
 end
 
 """

--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -36,6 +36,21 @@ function tsvd(t::AbstractTensorMap, (p₁, p₂)::Index2Tuple; kwargs...)
     return tsvd!(permute(t, (p₁, p₂); copy=true); kwargs...)
 end
 
+function LinearAlgebra.svdvals(t::AbstractTensorMap)
+    return SectorDict(c => LinearAlgebra.svdvals(b) for (c, b) in blocks(t))
+end
+function LinearAlgebra.svdvals!(t::AbstractTensorMap)
+    return SectorDict(c => LinearAlgebra.svdvals!(b) for (c, b) in blocks(t))
+end
+
+# TODO: decide if we want to keep these specializations:
+function LinearAlgebra.svdvals(t::TrivialTensorMap)
+    return LinearAlgebra.svdvals(t.data)
+end
+function LinearAlgebra.svdvals!(t::TrivialTensorMap)
+    return LinearAlgebra.svdvals!(t.data)
+end
+
 """
     leftorth(t::AbstractTensorMap, (leftind, rightind)::Index2Tuple;
                 alg::OrthogonalFactorizationAlgorithm = QRpos()) -> Q, R

--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -36,17 +36,12 @@ function tsvd(t::AbstractTensorMap, (p₁, p₂)::Index2Tuple; kwargs...)
     return tsvd!(permute(t, (p₁, p₂); copy=true); kwargs...)
 end
 
-function LinearAlgebra.svdvals(t::AbstractTensorMap)
-    return SectorDict(c => LinearAlgebra.svdvals(b) for (c, b) in blocks(t))
-end
+LinearAlgebra.svdvals(t::AbstractTensorMap) = LinearAlgebra.svdvals!(copy(t))
 function LinearAlgebra.svdvals!(t::AbstractTensorMap)
     return SectorDict(c => LinearAlgebra.svdvals!(b) for (c, b) in blocks(t))
 end
 
 # TODO: decide if we want to keep these specializations:
-function LinearAlgebra.svdvals(t::TrivialTensorMap)
-    return LinearAlgebra.svdvals(t.data)
-end
 function LinearAlgebra.svdvals!(t::TrivialTensorMap)
     return LinearAlgebra.svdvals!(t.data)
 end
@@ -184,16 +179,13 @@ function LinearAlgebra.eigen(t::AbstractTensorMap, (p₁, p₂)::Index2Tuple;
 end
 
 function LinearAlgebra.eigvals(t::AbstractTensorMap; kwargs...)
-    return SectorDict(c => LinearAlgebra.eigvals(b; kwargs...) for (c, b) in blocks(t))
+    return LinearAlgebra.eigvals!(copy(t); kwargs...)
 end
 function LinearAlgebra.eigvals!(t::AbstractTensorMap; kwargs...)
     return SectorDict(c => LinearAlgebra.eigvals!(b; kwargs...) for (c, b) in blocks(t))
 end
 
 # TODO: decide if we want to keep these specializations:
-function LinearAlgebra.eigvals(t::TrivialTensorMap; kwargs...)
-    return LinearAlgebra.eigvals(t.data; kwargs...)
-end
 function LinearAlgebra.eigvals!(t::TrivialTensorMap; kwargs...)
     return LinearAlgebra.eigvals!(t.data; kwargs...)
 end

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -157,24 +157,13 @@ end
 # ----------------
 # TODO: consider adding a specialised DiagonalTensorMap type
 function LinearAlgebra.diag(t::AbstractTensorMap)
-    if sectortype(t) === Trivial
-        return LinearAlgebra.diag(block(t, Trivial()))
-    else
-        return SectorDict(c => LinearAlgebra.diag(b) for (c, b) in blocks(t))
-    end
-end
-
-function LinearAlgebra.diagm(codom::VectorSpace, dom::VectorSpace, v::AbstractVector)
-    sp = codom ← dom
-    @assert sectortype(sp) === Trivial
-    return TensorMap(LinearAlgebra.diagm(dim(codom), dim(dom), v), sp)
+    return SectorDict(c => LinearAlgebra.diag(b) for (c, b) in blocks(t))
 end
 function LinearAlgebra.diagm(codom::VectorSpace, dom::VectorSpace, v::SectorDict)
     return TensorMap(SectorDict(c => LinearAlgebra.diagm(blockdim(codom, c),
                                                          blockdim(dom, c), b)
                                 for (c, b) in v), codom ← dom)
 end
-
 LinearAlgebra.isdiag(t::AbstractTensorMap) = all(LinearAlgebra.isdiag, values(blocks(t)))
 
 # In-place methods

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -46,6 +46,23 @@ function FiniteDifferences.to_vec(t::AbstractTensorMap)
 end
 FiniteDifferences.to_vec(t::TensorKit.AdjointTensorMap) = to_vec(copy(t))
 
+# make sure that norms are computed correctly:
+function FiniteDifferences.to_vec(t::TensorKit.SectorDict)
+    T = scalartype(valtype(t))
+    vec = mapreduce(vcat, t; init=T[]) do (c, b)
+        return reshape(b, :) .* sqrt(dim(c))
+    end
+    vec_real = T <: Real ? vec : collect(reinterpret(real(T), vec))
+
+    function from_vec(x_real)
+        x = T <: Real ? x_real : reinterpret(T, x_real)
+        ctr = 0
+        return TensorKit.SectorDict(c => (n = length(b); b′ = reshape(view(x, ctr .+ (1:n)), size(b)) ./ sqrt(dim(c)); ctr += n; b′)
+                                    for (c, b) in t)
+    end
+    return vec_real, from_vec
+end
+
 function _randomize!(a::TensorMap)
     for b in values(blocks(a))
         copyto!(b, randn(size(b)))
@@ -68,11 +85,17 @@ end
 function ChainRulesCore.rrule(::typeof(TensorKit.tsvd), args...; kwargs...)
     return ChainRulesCore.rrule(tsvd!, args...; kwargs...)
 end
+function ChainRulesCore.rrule(::typeof(LinearAlgebra.svdvals), args...; kwargs...)
+    return ChainRulesCore.rrule(svdvals!, args...; kwargs...)
+end
 function ChainRulesCore.rrule(::typeof(TensorKit.eig), args...; kwargs...)
     return ChainRulesCore.rrule(eig!, args...; kwargs...)
 end
 function ChainRulesCore.rrule(::typeof(TensorKit.eigh), args...; kwargs...)
     return ChainRulesCore.rrule(eigh!, args...; kwargs...)
+end
+function ChainRulesCore.rrule(::typeof(LinearAlgebra.eigvals), args...; kwargs...)
+    return ChainRulesCore.rrule(eigvals!, args...; kwargs...)
 end
 function ChainRulesCore.rrule(::typeof(TensorKit.leftorth), args...; kwargs...)
     return ChainRulesCore.rrule(leftorth!, args...; kwargs...)
@@ -129,130 +152,130 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
 
 @timedtestset "Automatic Differentiation with spacetype $(TensorKit.type_repr(eltype(V)))" verbose = true for V in
                                                                                                               Vlist
-    @timedtestset "Basic Linear Algebra with scalartype $T" for T in (Float64, ComplexF64)
-        A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
-        B = TensorMap(randn, T, space(A))
+    # @timedtestset "Basic Linear Algebra with scalartype $T" for T in (Float64, ComplexF64)
+    #     A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
+    #     B = TensorMap(randn, T, space(A))
+    #
+    #     test_rrule(+, A, B)
+    #     test_rrule(-, A)
+    #     test_rrule(-, A, B)
+    #
+    #     α = randn(T)
+    #     test_rrule(*, α, A)
+    #     test_rrule(*, A, α)
+    #
+    #     C = TensorMap(randn, T, domain(A), codomain(A))
+    #     test_rrule(*, A, C)
+    #
+    #     test_rrule(permute, A, ((1, 3, 2), (5, 4)))
+    #
+    #     D = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3])
+    #     E = TensorMap(randn, T, V[4] ← V[5])
+    #     test_rrule(⊗, D, E)
+    # end
 
-        test_rrule(+, A, B)
-        test_rrule(-, A)
-        test_rrule(-, A, B)
+    # @timedtestset "Linear Algebra part II with scalartype $T" for T in (Float64, ComplexF64)
+    #     for i in 1:3
+    #         E = TensorMap(randn, T, ⊗(V[1:i]...) ← ⊗(V[1:i]...))
+    #         test_rrule(LinearAlgebra.tr, E)
+    #     end
+    #
+    #     A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
+    #     test_rrule(LinearAlgebra.adjoint, A)
+    #     test_rrule(LinearAlgebra.norm, A, 2)
+    # end
 
-        α = randn(T)
-        test_rrule(*, α, A)
-        test_rrule(*, A, α)
-
-        C = TensorMap(randn, T, domain(A), codomain(A))
-        test_rrule(*, A, C)
-
-        test_rrule(permute, A, ((1, 3, 2), (5, 4)))
-
-        D = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3])
-        E = TensorMap(randn, T, V[4] ← V[5])
-        test_rrule(⊗, D, E)
-    end
-
-    @timedtestset "Linear Algebra part II with scalartype $T" for T in (Float64, ComplexF64)
-        for i in 1:3
-            E = TensorMap(randn, T, ⊗(V[1:i]...) ← ⊗(V[1:i]...))
-            test_rrule(LinearAlgebra.tr, E)
-        end
-
-        A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
-        test_rrule(LinearAlgebra.adjoint, A)
-        test_rrule(LinearAlgebra.norm, A, 2)
-    end
-
-    @timedtestset "TensorOperations with scalartype $T" for T in (Float64, ComplexF64)
-        atol = precision(T)
-        rtol = precision(T)
-
-        @timedtestset "tensortrace!" begin
-            for _ in 1:5
-                k1 = rand(0:3)
-                k2 = k1 == 3 ? 1 : rand(1:2)
-                V1 = map(v -> rand(Bool) ? v' : v, rand(V, k1))
-                V2 = map(v -> rand(Bool) ? v' : v, rand(V, k2))
-
-                (_p, _q) = randindextuple(k1 + 2 * k2, k1)
-                p = _repartition(_p, rand(0:k1))
-                q = _repartition(_q, k2)
-                ip = _repartition(invperm(linearize((_p, _q))), rand(0:(k1 + 2 * k2)))
-                A = TensorMap(randn, T, permute(prod(V1) ⊗ prod(V2) ← prod(V2), ip))
-
-                α = randn(T)
-                β = randn(T)
-                for conjA in (:N, :C)
-                    C = _randomize!(TensorOperations.tensoralloc_add(T, p, A, conjA, false))
-                    test_rrule(tensortrace!, C, p, A, q, conjA, α, β; atol, rtol)
-                end
-            end
-        end
-
-        @timedtestset "tensoradd!" begin
-            A = TensorMap(randn, T, V[1] ⊗ V[2] ⊗ V[3] ← V[4] ⊗ V[5])
-            α = randn(T)
-            β = randn(T)
-
-            # repeat a couple times to get some distribution of arrows
-            for _ in 1:5
-                p = randindextuple(length(V))
-
-                C1 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :N, false))
-                test_rrule(tensoradd!, C1, p, A, :N, α, β; atol, rtol)
-
-                C2 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :C, false))
-                test_rrule(tensoradd!, C2, p, A, :C, α, β; atol, rtol)
-
-                A = rand(Bool) ? C1 : C2
-            end
-        end
-
-        @timedtestset "tensorcontract!" begin
-            for _ in 1:5
-                d = 0
-                local V1, V2, V3
-                # retry a couple times to make sure there are at least some nonzero elements
-                for _ in 1:10
-                    k1 = rand(0:3)
-                    k2 = rand(0:2)
-                    k3 = rand(0:2)
-                    V1 = prod(v -> rand(Bool) ? v' : v, rand(V, k1); init=one(V[1]))
-                    V2 = prod(v -> rand(Bool) ? v' : v, rand(V, k2); init=one(V[1]))
-                    V3 = prod(v -> rand(Bool) ? v' : v, rand(V, k3); init=one(V[1]))
-                    d = min(dim(V1 ← V2), dim(V1' ← V2), dim(V2 ← V3), dim(V2' ← V3))
-                    d > 0 && break
-                end
-                ipA = randindextuple(length(V1) + length(V2))
-                pA = _repartition(invperm(linearize(ipA)), length(V1))
-                ipB = randindextuple(length(V2) + length(V3))
-                pB = _repartition(invperm(linearize(ipB)), length(V2))
-                pAB = randindextuple(length(V1) + length(V3))
-
-                α = randn(T)
-                β = randn(T)
-                V2_conj = prod(conj, V2; init=one(V[1]))
-
-                for conjA in (:N, :C), conjB in (:N, :C)
-                    A = TensorMap(randn, T,
-                                  permute(V1 ← (conjA === :C ? V2_conj : V2), ipA))
-                    B = TensorMap(randn, T,
-                                  permute((conjB === :C ? V2_conj : V2) ← V3, ipB))
-                    C = _randomize!(TensorOperations.tensoralloc_contract(T, pAB, A, pA,
-                                                                          conjA,
-                                                                          B, pB, conjB,
-                                                                          false))
-                    test_rrule(tensorcontract!, C, pAB,
-                               A, pA, conjA, B, pB, conjB,
-                               α, β; atol, rtol)
-                end
-            end
-        end
-
-        @timedtestset "tensorscalar" begin
-            A = Tensor(randn, T, ProductSpace{typeof(V[1]),0}())
-            test_rrule(tensorscalar, A)
-        end
-    end
+    # @timedtestset "TensorOperations with scalartype $T" for T in (Float64, ComplexF64)
+    #     atol = precision(T)
+    #     rtol = precision(T)
+    #
+    #     @timedtestset "tensortrace!" begin
+    #         for _ in 1:5
+    #             k1 = rand(0:3)
+    #             k2 = k1 == 3 ? 1 : rand(1:2)
+    #             V1 = map(v -> rand(Bool) ? v' : v, rand(V, k1))
+    #             V2 = map(v -> rand(Bool) ? v' : v, rand(V, k2))
+    #
+    #             (_p, _q) = randindextuple(k1 + 2 * k2, k1)
+    #             p = _repartition(_p, rand(0:k1))
+    #             q = _repartition(_q, k2)
+    #             ip = _repartition(invperm(linearize((_p, _q))), rand(0:(k1 + 2 * k2)))
+    #             A = TensorMap(randn, T, permute(prod(V1) ⊗ prod(V2) ← prod(V2), ip))
+    #
+    #             α = randn(T)
+    #             β = randn(T)
+    #             for conjA in (:N, :C)
+    #                 C = _randomize!(TensorOperations.tensoralloc_add(T, p, A, conjA, false))
+    #                 test_rrule(tensortrace!, C, p, A, q, conjA, α, β; atol, rtol)
+    #             end
+    #         end
+    #     end
+    #
+    #     @timedtestset "tensoradd!" begin
+    #         A = TensorMap(randn, T, V[1] ⊗ V[2] ⊗ V[3] ← V[4] ⊗ V[5])
+    #         α = randn(T)
+    #         β = randn(T)
+    #
+    #         # repeat a couple times to get some distribution of arrows
+    #         for _ in 1:5
+    #             p = randindextuple(length(V))
+    #
+    #             C1 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :N, false))
+    #             test_rrule(tensoradd!, C1, p, A, :N, α, β; atol, rtol)
+    #
+    #             C2 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :C, false))
+    #             test_rrule(tensoradd!, C2, p, A, :C, α, β; atol, rtol)
+    #
+    #             A = rand(Bool) ? C1 : C2
+    #         end
+    #     end
+    #
+    #     @timedtestset "tensorcontract!" begin
+    #         for _ in 1:5
+    #             d = 0
+    #             local V1, V2, V3
+    #             # retry a couple times to make sure there are at least some nonzero elements
+    #             for _ in 1:10
+    #                 k1 = rand(0:3)
+    #                 k2 = rand(0:2)
+    #                 k3 = rand(0:2)
+    #                 V1 = prod(v -> rand(Bool) ? v' : v, rand(V, k1); init=one(V[1]))
+    #                 V2 = prod(v -> rand(Bool) ? v' : v, rand(V, k2); init=one(V[1]))
+    #                 V3 = prod(v -> rand(Bool) ? v' : v, rand(V, k3); init=one(V[1]))
+    #                 d = min(dim(V1 ← V2), dim(V1' ← V2), dim(V2 ← V3), dim(V2' ← V3))
+    #                 d > 0 && break
+    #             end
+    #             ipA = randindextuple(length(V1) + length(V2))
+    #             pA = _repartition(invperm(linearize(ipA)), length(V1))
+    #             ipB = randindextuple(length(V2) + length(V3))
+    #             pB = _repartition(invperm(linearize(ipB)), length(V2))
+    #             pAB = randindextuple(length(V1) + length(V3))
+    #
+    #             α = randn(T)
+    #             β = randn(T)
+    #             V2_conj = prod(conj, V2; init=one(V[1]))
+    #
+    #             for conjA in (:N, :C), conjB in (:N, :C)
+    #                 A = TensorMap(randn, T,
+    #                               permute(V1 ← (conjA === :C ? V2_conj : V2), ipA))
+    #                 B = TensorMap(randn, T,
+    #                               permute((conjB === :C ? V2_conj : V2) ← V3, ipB))
+    #                 C = _randomize!(TensorOperations.tensoralloc_contract(T, pAB, A, pA,
+    #                                                                       conjA,
+    #                                                                       B, pB, conjB,
+    #                                                                       false))
+    #                 test_rrule(tensorcontract!, C, pAB,
+    #                            A, pA, conjA, B, pB, conjB,
+    #                            α, β; atol, rtol)
+    #             end
+    #         end
+    #     end
+    #
+    #     @timedtestset "tensorscalar" begin
+    #         A = Tensor(randn, T, ProductSpace{typeof(V[1]),0}())
+    #         test_rrule(tensorscalar, A)
+    #     end
+    # end
 
     @timedtestset "Factorizations with scalartype $T" for T in (Float64, ComplexF64)
         A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
@@ -261,99 +284,110 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
         H = TensorMap(randn, T, V[3] ⊗ V[4] ← V[3] ⊗ V[4])
         H = (H + H') / 2
         atol = precision(T)
+        #
+        # for alg in (TensorKit.QR(), TensorKit.QRpos())
+        #     test_rrule(leftorth, A; fkwargs=(; alg=alg), atol)
+        #     test_rrule(leftorth, B; fkwargs=(; alg=alg), atol)
+        #     test_rrule(leftorth, C; fkwargs=(; alg=alg), atol)
+        # end
+        #
+        # for alg in (TensorKit.LQ(), TensorKit.LQpos())
+        #     test_rrule(rightorth, A; fkwargs=(; alg=alg), atol)
+        #     test_rrule(rightorth, B; fkwargs=(; alg=alg), atol)
+        #     test_rrule(rightorth, C; fkwargs=(; alg=alg), atol)
+        # end
+        #
+        # let (D, V) = eig(C)
+        #     ΔD = TensorMap(randn, scalartype(D), space(D))
+        #     ΔV = TensorMap(randn, scalartype(V), space(V))
+        #     gaugepart = V' * ΔV
+        #     for (c, b) in blocks(gaugepart)
+        #         mul!(block(ΔV, c), inv(block(V, c))', Diagonal(diag(b)), -1, 1)
+        #     end
+        #     test_rrule(eig, C; atol, output_tangent=(ΔD, ΔV))
+        # end
+        #
+        # let (D, U) = eigh′(H)
+        #     ΔD = TensorMap(randn, scalartype(D), space(D))
+        #     ΔU = TensorMap(randn, scalartype(U), space(U))
+        #     if T <: Complex
+        #         gaugepart = U' * ΔU
+        #         for (c, b) in blocks(gaugepart)
+        #             mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
+        #         end
+        #     end
+        #     test_rrule(eigh′, H; atol, output_tangent=(ΔD, ΔU))
+        # end
+        #
+        # let (U, S, V, ϵ) = tsvd(A)
+        #     ΔU = TensorMap(randn, scalartype(U), space(U))
+        #     ΔS = TensorMap(randn, scalartype(S), space(S))
+        #     ΔV = TensorMap(randn, scalartype(V), space(V))
+        #     if T <: Complex # remove gauge dependent components
+        #         gaugepart = U' * ΔU + V * ΔV'
+        #         for (c, b) in blocks(gaugepart)
+        #             mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
+        #         end
+        #     end
+        #     test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
+        #
+        #     allS = mapreduce(x -> diag(x[2]), vcat, blocks(S))
+        #     truncval = (maximum(allS) + minimum(allS)) / 2
+        #     U, S, V, ϵ = tsvd(A; trunc=truncerr(truncval))
+        #     ΔU = TensorMap(randn, scalartype(U), space(U))
+        #     ΔS = TensorMap(randn, scalartype(S), space(S))
+        #     ΔV = TensorMap(randn, scalartype(V), space(V))
+        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+        #     test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
+        #                fkwargs=(; trunc=truncerr(truncval)))
+        # end
+        #
+        # let (U, S, V, ϵ) = tsvd(B)
+        #     ΔU = TensorMap(randn, scalartype(U), space(U))
+        #     ΔS = TensorMap(randn, scalartype(S), space(S))
+        #     ΔV = TensorMap(randn, scalartype(V), space(V))
+        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+        #     test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
+        #
+        #     Vtrunc = spacetype(S)(TensorKit.SectorDict(c => ceil(Int, size(b, 1) / 2)
+        #                                                for (c, b) in blocks(S)))
+        #
+        #     U, S, V, ϵ = tsvd(B; trunc=truncspace(Vtrunc))
+        #     ΔU = TensorMap(randn, scalartype(U), space(U))
+        #     ΔS = TensorMap(randn, scalartype(S), space(S))
+        #     ΔV = TensorMap(randn, scalartype(V), space(V))
+        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+        #     test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
+        #                fkwargs=(; trunc=truncspace(Vtrunc)))
+        # end
+        #
+        # let (U, S, V, ϵ) = tsvd(C)
+        #     ΔU = TensorMap(randn, scalartype(U), space(U))
+        #     ΔS = TensorMap(randn, scalartype(S), space(S))
+        #     ΔV = TensorMap(randn, scalartype(V), space(V))
+        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+        #     test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
+        #
+        #     c, = TensorKit.MatrixAlgebra._argmax(x -> sqrt(dim(x[1])) * maximum(diag(x[2])),
+        #                                          blocks(S))
+        #     U, S, V, ϵ = tsvd(C; trunc=truncdim(2 * dim(c)))
+        #     ΔU = TensorMap(randn, scalartype(U), space(U))
+        #     ΔS = TensorMap(randn, scalartype(S), space(S))
+        #     ΔV = TensorMap(randn, scalartype(V), space(V))
+        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+        #     test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
+        #                fkwargs=(; trunc=truncdim(2 * dim(c))))
+        # end
 
-        for alg in (TensorKit.QR(), TensorKit.QRpos())
-            test_rrule(leftorth, A; fkwargs=(; alg=alg), atol)
-            test_rrule(leftorth, B; fkwargs=(; alg=alg), atol)
-            test_rrule(leftorth, C; fkwargs=(; alg=alg), atol)
+        let D = LinearAlgebra.eigvals(C)
+            ΔD = diag(TensorMap(randn, complex(scalartype(C)), space(C)))
+            test_rrule(LinearAlgebra.eigvals, C; atol, output_tangent=ΔD,
+                       fkwargs=(; sortby=nothing))
         end
 
-        for alg in (TensorKit.LQ(), TensorKit.LQpos())
-            test_rrule(rightorth, A; fkwargs=(; alg=alg), atol)
-            test_rrule(rightorth, B; fkwargs=(; alg=alg), atol)
-            test_rrule(rightorth, C; fkwargs=(; alg=alg), atol)
-        end
-
-        let (D, V) = eig(C)
-            ΔD = TensorMap(randn, scalartype(D), space(D))
-            ΔV = TensorMap(randn, scalartype(V), space(V))
-            gaugepart = V' * ΔV
-            for (c, b) in blocks(gaugepart)
-                mul!(block(ΔV, c), inv(block(V, c))', Diagonal(diag(b)), -1, 1)
-            end
-            test_rrule(eig, C; atol, output_tangent=(ΔD, ΔV))
-        end
-
-        let (D, U) = eigh′(H)
-            ΔD = TensorMap(randn, scalartype(D), space(D))
-            ΔU = TensorMap(randn, scalartype(U), space(U))
-            if T <: Complex
-                gaugepart = U' * ΔU
-                for (c, b) in blocks(gaugepart)
-                    mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
-                end
-            end
-            test_rrule(eigh′, H; atol, output_tangent=(ΔD, ΔU))
-        end
-
-        let (U, S, V, ϵ) = tsvd(A)
-            ΔU = TensorMap(randn, scalartype(U), space(U))
-            ΔS = TensorMap(randn, scalartype(S), space(S))
-            ΔV = TensorMap(randn, scalartype(V), space(V))
-            if T <: Complex # remove gauge dependent components
-                gaugepart = U' * ΔU + V * ΔV'
-                for (c, b) in blocks(gaugepart)
-                    mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
-                end
-            end
-            test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
-
-            allS = mapreduce(x -> diag(x[2]), vcat, blocks(S))
-            truncval = (maximum(allS) + minimum(allS)) / 2
-            U, S, V, ϵ = tsvd(A; trunc=truncerr(truncval))
-            ΔU = TensorMap(randn, scalartype(U), space(U))
-            ΔS = TensorMap(randn, scalartype(S), space(S))
-            ΔV = TensorMap(randn, scalartype(V), space(V))
-            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-            test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
-                       fkwargs=(; trunc=truncerr(truncval)))
-        end
-
-        let (U, S, V, ϵ) = tsvd(B)
-            ΔU = TensorMap(randn, scalartype(U), space(U))
-            ΔS = TensorMap(randn, scalartype(S), space(S))
-            ΔV = TensorMap(randn, scalartype(V), space(V))
-            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-            test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
-
-            Vtrunc = spacetype(S)(TensorKit.SectorDict(c => ceil(Int, size(b, 1) / 2)
-                                                       for (c, b) in blocks(S)))
-
-            U, S, V, ϵ = tsvd(B; trunc=truncspace(Vtrunc))
-            ΔU = TensorMap(randn, scalartype(U), space(U))
-            ΔS = TensorMap(randn, scalartype(S), space(S))
-            ΔV = TensorMap(randn, scalartype(V), space(V))
-            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-            test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
-                       fkwargs=(; trunc=truncspace(Vtrunc)))
-        end
-
-        let (U, S, V, ϵ) = tsvd(C)
-            ΔU = TensorMap(randn, scalartype(U), space(U))
-            ΔS = TensorMap(randn, scalartype(S), space(S))
-            ΔV = TensorMap(randn, scalartype(V), space(V))
-            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-            test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
-
-            c, = TensorKit.MatrixAlgebra._argmax(x -> sqrt(dim(x[1])) * maximum(diag(x[2])),
-                                                 blocks(S))
-            U, S, V, ϵ = tsvd(C; trunc=truncdim(2 * dim(c)))
-            ΔU = TensorMap(randn, scalartype(U), space(U))
-            ΔS = TensorMap(randn, scalartype(S), space(S))
-            ΔV = TensorMap(randn, scalartype(V), space(V))
-            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-            test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
-                       fkwargs=(; trunc=truncdim(2 * dim(c))))
+        let S = LinearAlgebra.svdvals(C)
+            ΔS = diag(TensorMap(randn, real(scalartype(C)), space(C)))
+            test_rrule(LinearAlgebra.svdvals, C; atol, output_tangent=ΔS)
         end
     end
 end

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -57,7 +57,11 @@ function FiniteDifferences.to_vec(t::TensorKit.SectorDict)
     function from_vec(x_real)
         x = T <: Real ? x_real : reinterpret(T, x_real)
         ctr = 0
-        return TensorKit.SectorDict(c => (n = length(b); b′ = reshape(view(x, ctr .+ (1:n)), size(b)) ./ sqrt(dim(c)); ctr += n; b′)
+        return TensorKit.SectorDict(c => (n = length(b);
+                                          b′ = reshape(view(x, ctr .+ (1:n)), size(b)) ./
+                                               sqrt(dim(c));
+                                          ctr += n;
+                                          b′)
                                     for (c, b) in t)
     end
     return vec_real, from_vec
@@ -152,130 +156,130 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
 
 @timedtestset "Automatic Differentiation with spacetype $(TensorKit.type_repr(eltype(V)))" verbose = true for V in
                                                                                                               Vlist
-    # @timedtestset "Basic Linear Algebra with scalartype $T" for T in (Float64, ComplexF64)
-    #     A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
-    #     B = TensorMap(randn, T, space(A))
-    #
-    #     test_rrule(+, A, B)
-    #     test_rrule(-, A)
-    #     test_rrule(-, A, B)
-    #
-    #     α = randn(T)
-    #     test_rrule(*, α, A)
-    #     test_rrule(*, A, α)
-    #
-    #     C = TensorMap(randn, T, domain(A), codomain(A))
-    #     test_rrule(*, A, C)
-    #
-    #     test_rrule(permute, A, ((1, 3, 2), (5, 4)))
-    #
-    #     D = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3])
-    #     E = TensorMap(randn, T, V[4] ← V[5])
-    #     test_rrule(⊗, D, E)
-    # end
+    @timedtestset "Basic Linear Algebra with scalartype $T" for T in (Float64, ComplexF64)
+        A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
+        B = TensorMap(randn, T, space(A))
 
-    # @timedtestset "Linear Algebra part II with scalartype $T" for T in (Float64, ComplexF64)
-    #     for i in 1:3
-    #         E = TensorMap(randn, T, ⊗(V[1:i]...) ← ⊗(V[1:i]...))
-    #         test_rrule(LinearAlgebra.tr, E)
-    #     end
-    #
-    #     A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
-    #     test_rrule(LinearAlgebra.adjoint, A)
-    #     test_rrule(LinearAlgebra.norm, A, 2)
-    # end
+        test_rrule(+, A, B)
+        test_rrule(-, A)
+        test_rrule(-, A, B)
 
-    # @timedtestset "TensorOperations with scalartype $T" for T in (Float64, ComplexF64)
-    #     atol = precision(T)
-    #     rtol = precision(T)
-    #
-    #     @timedtestset "tensortrace!" begin
-    #         for _ in 1:5
-    #             k1 = rand(0:3)
-    #             k2 = k1 == 3 ? 1 : rand(1:2)
-    #             V1 = map(v -> rand(Bool) ? v' : v, rand(V, k1))
-    #             V2 = map(v -> rand(Bool) ? v' : v, rand(V, k2))
-    #
-    #             (_p, _q) = randindextuple(k1 + 2 * k2, k1)
-    #             p = _repartition(_p, rand(0:k1))
-    #             q = _repartition(_q, k2)
-    #             ip = _repartition(invperm(linearize((_p, _q))), rand(0:(k1 + 2 * k2)))
-    #             A = TensorMap(randn, T, permute(prod(V1) ⊗ prod(V2) ← prod(V2), ip))
-    #
-    #             α = randn(T)
-    #             β = randn(T)
-    #             for conjA in (:N, :C)
-    #                 C = _randomize!(TensorOperations.tensoralloc_add(T, p, A, conjA, false))
-    #                 test_rrule(tensortrace!, C, p, A, q, conjA, α, β; atol, rtol)
-    #             end
-    #         end
-    #     end
-    #
-    #     @timedtestset "tensoradd!" begin
-    #         A = TensorMap(randn, T, V[1] ⊗ V[2] ⊗ V[3] ← V[4] ⊗ V[5])
-    #         α = randn(T)
-    #         β = randn(T)
-    #
-    #         # repeat a couple times to get some distribution of arrows
-    #         for _ in 1:5
-    #             p = randindextuple(length(V))
-    #
-    #             C1 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :N, false))
-    #             test_rrule(tensoradd!, C1, p, A, :N, α, β; atol, rtol)
-    #
-    #             C2 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :C, false))
-    #             test_rrule(tensoradd!, C2, p, A, :C, α, β; atol, rtol)
-    #
-    #             A = rand(Bool) ? C1 : C2
-    #         end
-    #     end
-    #
-    #     @timedtestset "tensorcontract!" begin
-    #         for _ in 1:5
-    #             d = 0
-    #             local V1, V2, V3
-    #             # retry a couple times to make sure there are at least some nonzero elements
-    #             for _ in 1:10
-    #                 k1 = rand(0:3)
-    #                 k2 = rand(0:2)
-    #                 k3 = rand(0:2)
-    #                 V1 = prod(v -> rand(Bool) ? v' : v, rand(V, k1); init=one(V[1]))
-    #                 V2 = prod(v -> rand(Bool) ? v' : v, rand(V, k2); init=one(V[1]))
-    #                 V3 = prod(v -> rand(Bool) ? v' : v, rand(V, k3); init=one(V[1]))
-    #                 d = min(dim(V1 ← V2), dim(V1' ← V2), dim(V2 ← V3), dim(V2' ← V3))
-    #                 d > 0 && break
-    #             end
-    #             ipA = randindextuple(length(V1) + length(V2))
-    #             pA = _repartition(invperm(linearize(ipA)), length(V1))
-    #             ipB = randindextuple(length(V2) + length(V3))
-    #             pB = _repartition(invperm(linearize(ipB)), length(V2))
-    #             pAB = randindextuple(length(V1) + length(V3))
-    #
-    #             α = randn(T)
-    #             β = randn(T)
-    #             V2_conj = prod(conj, V2; init=one(V[1]))
-    #
-    #             for conjA in (:N, :C), conjB in (:N, :C)
-    #                 A = TensorMap(randn, T,
-    #                               permute(V1 ← (conjA === :C ? V2_conj : V2), ipA))
-    #                 B = TensorMap(randn, T,
-    #                               permute((conjB === :C ? V2_conj : V2) ← V3, ipB))
-    #                 C = _randomize!(TensorOperations.tensoralloc_contract(T, pAB, A, pA,
-    #                                                                       conjA,
-    #                                                                       B, pB, conjB,
-    #                                                                       false))
-    #                 test_rrule(tensorcontract!, C, pAB,
-    #                            A, pA, conjA, B, pB, conjB,
-    #                            α, β; atol, rtol)
-    #             end
-    #         end
-    #     end
-    #
-    #     @timedtestset "tensorscalar" begin
-    #         A = Tensor(randn, T, ProductSpace{typeof(V[1]),0}())
-    #         test_rrule(tensorscalar, A)
-    #     end
-    # end
+        α = randn(T)
+        test_rrule(*, α, A)
+        test_rrule(*, A, α)
+
+        C = TensorMap(randn, T, domain(A), codomain(A))
+        test_rrule(*, A, C)
+
+        test_rrule(permute, A, ((1, 3, 2), (5, 4)))
+
+        D = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3])
+        E = TensorMap(randn, T, V[4] ← V[5])
+        test_rrule(⊗, D, E)
+    end
+
+    @timedtestset "Linear Algebra part II with scalartype $T" for T in (Float64, ComplexF64)
+        for i in 1:3
+            E = TensorMap(randn, T, ⊗(V[1:i]...) ← ⊗(V[1:i]...))
+            test_rrule(LinearAlgebra.tr, E)
+        end
+
+        A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
+        test_rrule(LinearAlgebra.adjoint, A)
+        test_rrule(LinearAlgebra.norm, A, 2)
+    end
+
+    @timedtestset "TensorOperations with scalartype $T" for T in (Float64, ComplexF64)
+        atol = precision(T)
+        rtol = precision(T)
+
+        @timedtestset "tensortrace!" begin
+            for _ in 1:5
+                k1 = rand(0:3)
+                k2 = k1 == 3 ? 1 : rand(1:2)
+                V1 = map(v -> rand(Bool) ? v' : v, rand(V, k1))
+                V2 = map(v -> rand(Bool) ? v' : v, rand(V, k2))
+
+                (_p, _q) = randindextuple(k1 + 2 * k2, k1)
+                p = _repartition(_p, rand(0:k1))
+                q = _repartition(_q, k2)
+                ip = _repartition(invperm(linearize((_p, _q))), rand(0:(k1 + 2 * k2)))
+                A = TensorMap(randn, T, permute(prod(V1) ⊗ prod(V2) ← prod(V2), ip))
+
+                α = randn(T)
+                β = randn(T)
+                for conjA in (:N, :C)
+                    C = _randomize!(TensorOperations.tensoralloc_add(T, p, A, conjA, false))
+                    test_rrule(tensortrace!, C, p, A, q, conjA, α, β; atol, rtol)
+                end
+            end
+        end
+
+        @timedtestset "tensoradd!" begin
+            A = TensorMap(randn, T, V[1] ⊗ V[2] ⊗ V[3] ← V[4] ⊗ V[5])
+            α = randn(T)
+            β = randn(T)
+
+            # repeat a couple times to get some distribution of arrows
+            for _ in 1:5
+                p = randindextuple(length(V))
+
+                C1 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :N, false))
+                test_rrule(tensoradd!, C1, p, A, :N, α, β; atol, rtol)
+
+                C2 = _randomize!(TensorOperations.tensoralloc_add(T, p, A, :C, false))
+                test_rrule(tensoradd!, C2, p, A, :C, α, β; atol, rtol)
+
+                A = rand(Bool) ? C1 : C2
+            end
+        end
+
+        @timedtestset "tensorcontract!" begin
+            for _ in 1:5
+                d = 0
+                local V1, V2, V3
+                # retry a couple times to make sure there are at least some nonzero elements
+                for _ in 1:10
+                    k1 = rand(0:3)
+                    k2 = rand(0:2)
+                    k3 = rand(0:2)
+                    V1 = prod(v -> rand(Bool) ? v' : v, rand(V, k1); init=one(V[1]))
+                    V2 = prod(v -> rand(Bool) ? v' : v, rand(V, k2); init=one(V[1]))
+                    V3 = prod(v -> rand(Bool) ? v' : v, rand(V, k3); init=one(V[1]))
+                    d = min(dim(V1 ← V2), dim(V1' ← V2), dim(V2 ← V3), dim(V2' ← V3))
+                    d > 0 && break
+                end
+                ipA = randindextuple(length(V1) + length(V2))
+                pA = _repartition(invperm(linearize(ipA)), length(V1))
+                ipB = randindextuple(length(V2) + length(V3))
+                pB = _repartition(invperm(linearize(ipB)), length(V2))
+                pAB = randindextuple(length(V1) + length(V3))
+
+                α = randn(T)
+                β = randn(T)
+                V2_conj = prod(conj, V2; init=one(V[1]))
+
+                for conjA in (:N, :C), conjB in (:N, :C)
+                    A = TensorMap(randn, T,
+                                  permute(V1 ← (conjA === :C ? V2_conj : V2), ipA))
+                    B = TensorMap(randn, T,
+                                  permute((conjB === :C ? V2_conj : V2) ← V3, ipB))
+                    C = _randomize!(TensorOperations.tensoralloc_contract(T, pAB, A, pA,
+                                                                          conjA,
+                                                                          B, pB, conjB,
+                                                                          false))
+                    test_rrule(tensorcontract!, C, pAB,
+                               A, pA, conjA, B, pB, conjB,
+                               α, β; atol, rtol)
+                end
+            end
+        end
+
+        @timedtestset "tensorscalar" begin
+            A = Tensor(randn, T, ProductSpace{typeof(V[1]),0}())
+            test_rrule(tensorscalar, A)
+        end
+    end
 
     @timedtestset "Factorizations with scalartype $T" for T in (Float64, ComplexF64)
         A = TensorMap(randn, T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])
@@ -284,100 +288,100 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
         H = TensorMap(randn, T, V[3] ⊗ V[4] ← V[3] ⊗ V[4])
         H = (H + H') / 2
         atol = precision(T)
-        #
-        # for alg in (TensorKit.QR(), TensorKit.QRpos())
-        #     test_rrule(leftorth, A; fkwargs=(; alg=alg), atol)
-        #     test_rrule(leftorth, B; fkwargs=(; alg=alg), atol)
-        #     test_rrule(leftorth, C; fkwargs=(; alg=alg), atol)
-        # end
-        #
-        # for alg in (TensorKit.LQ(), TensorKit.LQpos())
-        #     test_rrule(rightorth, A; fkwargs=(; alg=alg), atol)
-        #     test_rrule(rightorth, B; fkwargs=(; alg=alg), atol)
-        #     test_rrule(rightorth, C; fkwargs=(; alg=alg), atol)
-        # end
-        #
-        # let (D, V) = eig(C)
-        #     ΔD = TensorMap(randn, scalartype(D), space(D))
-        #     ΔV = TensorMap(randn, scalartype(V), space(V))
-        #     gaugepart = V' * ΔV
-        #     for (c, b) in blocks(gaugepart)
-        #         mul!(block(ΔV, c), inv(block(V, c))', Diagonal(diag(b)), -1, 1)
-        #     end
-        #     test_rrule(eig, C; atol, output_tangent=(ΔD, ΔV))
-        # end
-        #
-        # let (D, U) = eigh′(H)
-        #     ΔD = TensorMap(randn, scalartype(D), space(D))
-        #     ΔU = TensorMap(randn, scalartype(U), space(U))
-        #     if T <: Complex
-        #         gaugepart = U' * ΔU
-        #         for (c, b) in blocks(gaugepart)
-        #             mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
-        #         end
-        #     end
-        #     test_rrule(eigh′, H; atol, output_tangent=(ΔD, ΔU))
-        # end
-        #
-        # let (U, S, V, ϵ) = tsvd(A)
-        #     ΔU = TensorMap(randn, scalartype(U), space(U))
-        #     ΔS = TensorMap(randn, scalartype(S), space(S))
-        #     ΔV = TensorMap(randn, scalartype(V), space(V))
-        #     if T <: Complex # remove gauge dependent components
-        #         gaugepart = U' * ΔU + V * ΔV'
-        #         for (c, b) in blocks(gaugepart)
-        #             mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
-        #         end
-        #     end
-        #     test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
-        #
-        #     allS = mapreduce(x -> diag(x[2]), vcat, blocks(S))
-        #     truncval = (maximum(allS) + minimum(allS)) / 2
-        #     U, S, V, ϵ = tsvd(A; trunc=truncerr(truncval))
-        #     ΔU = TensorMap(randn, scalartype(U), space(U))
-        #     ΔS = TensorMap(randn, scalartype(S), space(S))
-        #     ΔV = TensorMap(randn, scalartype(V), space(V))
-        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-        #     test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
-        #                fkwargs=(; trunc=truncerr(truncval)))
-        # end
-        #
-        # let (U, S, V, ϵ) = tsvd(B)
-        #     ΔU = TensorMap(randn, scalartype(U), space(U))
-        #     ΔS = TensorMap(randn, scalartype(S), space(S))
-        #     ΔV = TensorMap(randn, scalartype(V), space(V))
-        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-        #     test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
-        #
-        #     Vtrunc = spacetype(S)(TensorKit.SectorDict(c => ceil(Int, size(b, 1) / 2)
-        #                                                for (c, b) in blocks(S)))
-        #
-        #     U, S, V, ϵ = tsvd(B; trunc=truncspace(Vtrunc))
-        #     ΔU = TensorMap(randn, scalartype(U), space(U))
-        #     ΔS = TensorMap(randn, scalartype(S), space(S))
-        #     ΔV = TensorMap(randn, scalartype(V), space(V))
-        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-        #     test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
-        #                fkwargs=(; trunc=truncspace(Vtrunc)))
-        # end
-        #
-        # let (U, S, V, ϵ) = tsvd(C)
-        #     ΔU = TensorMap(randn, scalartype(U), space(U))
-        #     ΔS = TensorMap(randn, scalartype(S), space(S))
-        #     ΔV = TensorMap(randn, scalartype(V), space(V))
-        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-        #     test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
-        #
-        #     c, = TensorKit.MatrixAlgebra._argmax(x -> sqrt(dim(x[1])) * maximum(diag(x[2])),
-        #                                          blocks(S))
-        #     U, S, V, ϵ = tsvd(C; trunc=truncdim(2 * dim(c)))
-        #     ΔU = TensorMap(randn, scalartype(U), space(U))
-        #     ΔS = TensorMap(randn, scalartype(S), space(S))
-        #     ΔV = TensorMap(randn, scalartype(V), space(V))
-        #     T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
-        #     test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
-        #                fkwargs=(; trunc=truncdim(2 * dim(c))))
-        # end
+
+        for alg in (TensorKit.QR(), TensorKit.QRpos())
+            test_rrule(leftorth, A; fkwargs=(; alg=alg), atol)
+            test_rrule(leftorth, B; fkwargs=(; alg=alg), atol)
+            test_rrule(leftorth, C; fkwargs=(; alg=alg), atol)
+        end
+
+        for alg in (TensorKit.LQ(), TensorKit.LQpos())
+            test_rrule(rightorth, A; fkwargs=(; alg=alg), atol)
+            test_rrule(rightorth, B; fkwargs=(; alg=alg), atol)
+            test_rrule(rightorth, C; fkwargs=(; alg=alg), atol)
+        end
+
+        let (D, V) = eig(C)
+            ΔD = TensorMap(randn, scalartype(D), space(D))
+            ΔV = TensorMap(randn, scalartype(V), space(V))
+            gaugepart = V' * ΔV
+            for (c, b) in blocks(gaugepart)
+                mul!(block(ΔV, c), inv(block(V, c))', Diagonal(diag(b)), -1, 1)
+            end
+            test_rrule(eig, C; atol, output_tangent=(ΔD, ΔV))
+        end
+
+        let (D, U) = eigh′(H)
+            ΔD = TensorMap(randn, scalartype(D), space(D))
+            ΔU = TensorMap(randn, scalartype(U), space(U))
+            if T <: Complex
+                gaugepart = U' * ΔU
+                for (c, b) in blocks(gaugepart)
+                    mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
+                end
+            end
+            test_rrule(eigh′, H; atol, output_tangent=(ΔD, ΔU))
+        end
+
+        let (U, S, V, ϵ) = tsvd(A)
+            ΔU = TensorMap(randn, scalartype(U), space(U))
+            ΔS = TensorMap(randn, scalartype(S), space(S))
+            ΔV = TensorMap(randn, scalartype(V), space(V))
+            if T <: Complex # remove gauge dependent components
+                gaugepart = U' * ΔU + V * ΔV'
+                for (c, b) in blocks(gaugepart)
+                    mul!(block(ΔU, c), block(U, c), Diagonal(imag(diag(b))), -im, 1)
+                end
+            end
+            test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
+
+            allS = mapreduce(x -> diag(x[2]), vcat, blocks(S))
+            truncval = (maximum(allS) + minimum(allS)) / 2
+            U, S, V, ϵ = tsvd(A; trunc=truncerr(truncval))
+            ΔU = TensorMap(randn, scalartype(U), space(U))
+            ΔS = TensorMap(randn, scalartype(S), space(S))
+            ΔV = TensorMap(randn, scalartype(V), space(V))
+            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+            test_rrule(tsvd, A; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
+                       fkwargs=(; trunc=truncerr(truncval)))
+        end
+
+        let (U, S, V, ϵ) = tsvd(B)
+            ΔU = TensorMap(randn, scalartype(U), space(U))
+            ΔS = TensorMap(randn, scalartype(S), space(S))
+            ΔV = TensorMap(randn, scalartype(V), space(V))
+            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+            test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
+
+            Vtrunc = spacetype(S)(TensorKit.SectorDict(c => ceil(Int, size(b, 1) / 2)
+                                                       for (c, b) in blocks(S)))
+
+            U, S, V, ϵ = tsvd(B; trunc=truncspace(Vtrunc))
+            ΔU = TensorMap(randn, scalartype(U), space(U))
+            ΔS = TensorMap(randn, scalartype(S), space(S))
+            ΔV = TensorMap(randn, scalartype(V), space(V))
+            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+            test_rrule(tsvd, B; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
+                       fkwargs=(; trunc=truncspace(Vtrunc)))
+        end
+
+        let (U, S, V, ϵ) = tsvd(C)
+            ΔU = TensorMap(randn, scalartype(U), space(U))
+            ΔS = TensorMap(randn, scalartype(S), space(S))
+            ΔV = TensorMap(randn, scalartype(V), space(V))
+            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+            test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0))
+
+            c, = TensorKit.MatrixAlgebra._argmax(x -> sqrt(dim(x[1])) * maximum(diag(x[2])),
+                                                 blocks(S))
+            U, S, V, ϵ = tsvd(C; trunc=truncdim(2 * dim(c)))
+            ΔU = TensorMap(randn, scalartype(U), space(U))
+            ΔS = TensorMap(randn, scalartype(S), space(S))
+            ΔV = TensorMap(randn, scalartype(V), space(V))
+            T <: Complex && remove_svdgauge_depence!(ΔU, ΔV, U, S, V)
+            test_rrule(tsvd, C; atol, output_tangent=(ΔU, ΔS, ΔV, 0.0),
+                       fkwargs=(; trunc=truncdim(2 * dim(c))))
+        end
 
         let D = LinearAlgebra.eigvals(C)
             ΔD = diag(TensorMap(randn, complex(scalartype(C)), space(C)))

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -188,6 +188,14 @@ for V in spacelist
             @test Base.promote_typeof(t, tc) == typeof(tc)
             @test Base.promote_typeof(tc, t) == typeof(tc + t)
         end
+        @timedtestset "diag/diagm" begin
+            W = V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5
+            t = TensorMap(randn, ComplexF64, W)
+            d = LinearAlgebra.diag(t)
+            D = LinearAlgebra.diagm(codomain(t), domain(t), d)
+            @test LinearAlgebra.isdiag(D)
+            @test LinearAlgebra.diag(D) == d
+        end
         @timedtestset "Permutations: test via inner product invariance" begin
             W = V1 ⊗ V2 ⊗ V3 ⊗ V4 ⊗ V5
             t = Tensor(rand, ComplexF64, W)

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -408,7 +408,18 @@ for V in spacelist
                         @test UdU ≈ one(UdU)
                         VVd = V * V'
                         @test VVd ≈ one(VVd)
-                        @test U * S * V ≈ permute(t, ((3, 4, 2), (1, 5)))
+                        t2 = permute(t, ((3, 4, 2), (1, 5)))
+                        @test U * S * V ≈ t2
+
+                        s = LinearAlgebra.svdvals(t2)
+                        s′ = LinearAlgebra.diag(S)
+                        if s isa TensorKit.SectorDict
+                            for (c, b) in s
+                                @test b ≈ s′[c]
+                            end
+                        else
+                            @test s ≈ s′
+                        end
                     end
                 end
                 @testset "empty tensor" begin
@@ -457,6 +468,16 @@ for V in spacelist
                     D, V = eigen(t, ((1, 3), (2, 4)))
                     t2 = permute(t, ((1, 3), (2, 4)))
                     @test t2 * V ≈ V * D
+
+                    d = LinearAlgebra.eigvals(t2; sortby=nothing)
+                    d′ = LinearAlgebra.diag(D)
+                    if d isa TensorKit.SectorDict
+                        for (c, b) in d
+                            @test b ≈ d′[c]
+                        end
+                    else
+                        @test d ≈ d′
+                    end
 
                     # Somehow moving these test before the previous one gives rise to errors
                     # with T=Float32 on x86 platforms. Is this an OpenBLAS issue? 

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -421,12 +421,8 @@ for V in spacelist
 
                         s = LinearAlgebra.svdvals(t2)
                         s′ = LinearAlgebra.diag(S)
-                        if s isa TensorKit.SectorDict
-                            for (c, b) in s
-                                @test b ≈ s′[c]
-                            end
-                        else
-                            @test s ≈ s′
+                        for (c, b) in s
+                            @test b ≈ s′[c]
                         end
                     end
                 end
@@ -479,12 +475,8 @@ for V in spacelist
 
                     d = LinearAlgebra.eigvals(t2; sortby=nothing)
                     d′ = LinearAlgebra.diag(D)
-                    if d isa TensorKit.SectorDict
-                        for (c, b) in d
-                            @test b ≈ d′[c]
-                        end
-                    else
-                        @test d ≈ d′
+                    for (c, b) in d
+                        @test b ≈ d′[c]
                     end
 
                     # Somehow moving these test before the previous one gives rise to errors


### PR DESCRIPTION
This PR extends some of the LinearAlgebra functions for obtaining information about diagonal entries. This is particularly useful as it allows the definition of rrules for `eigvals` and `svdvals`, which would otherwise necessarily involve accessing tensormap data, an operation that typically breaks Zygote.

The implementation currently returns `Vector` objects for TrivialTensorMap's, and `SectorDict{I,Vector}` objects in all other cases. I agree that this would be more elegantly solved with something like `DiagonalTensorMap`, but as this is not (yet) implemented and requires a bit more effort, this could work as an intermediate solution.

Note however that this does introduce a subtlety when dealing with non-abelian symmetries, as this yields an intermediate representation where people will have to keep in mind that the inner product is non-trivial. 
See the finitedifferences implementation in test/ad.jl#L50 for the consequence.

I did not add any docstrings to these methods, as this really does form a valid implementation of the original functions (which thus already have docstrings), but I could of course add them if needed.

Finally, I choose to not include `eigvecs` into this PR, as the implementation of the `eig` functions and the respective gauge choices should be re-evaluated, which I think is beyond the scope of this PR, and thus the implementation would really boil down to `eigvecs(t) = eig(t)[2]`, which does not really yield large benefits at the moment.