### PR TITLE
Move FiniteDifferences support to package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,9 +16,11 @@ WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 
 [extensions]
 TensorKitChainRulesCoreExt = "ChainRulesCore"
+TensorKitFiniteDifferencesExt = "FiniteDifferences"
 
 [compat]
 Aqua = "0.6, 0.7, 0.8"
@@ -27,8 +29,8 @@ ChainRulesTestUtils = "1"
 Combinatorics = "1"
 FiniteDifferences = "0.12"
 HalfIntegers = "1"
-LinearAlgebra = "1"
 LRUCache = "1.0.2"
+LinearAlgebra = "1"
 PackageExtensionCompat = "1"
 Random = "1"
 Strided = "2"

--- a/ext/TensorKitFiniteDifferencesExt.jl
+++ b/ext/TensorKitFiniteDifferencesExt.jl
@@ -1,0 +1,31 @@
+module TensorKitFiniteDifferencesExt
+
+using TensorKit
+using FiniteDifferences
+
+function FiniteDifferences.to_vec(t::T) where {T<:TensorKit.TrivialTensorMap}
+    vec, from_vec = to_vec(t.data)
+    return vec, x -> T(from_vec(x), codomain(t), domain(t))
+end
+function FiniteDifferences.to_vec(t::AbstractTensorMap)
+    vec = mapreduce(vcat, blocks(t); init=scalartype(t)[]) do (c, b)
+        return reshape(b, :) .* sqrt(dim(c))
+    end
+    vec_real = scalartype(t) <: Real ? vec : collect(reinterpret(real(scalartype(t)), vec))
+
+    function from_vec(x_real)
+        x = scalartype(t) <: Real ? x_real : reinterpret(scalartype(t), x_real)
+        t′ = similar(t)
+        ctr = 0
+        for (c, b) in blocks(t′)
+            n = length(b)
+            copyto!(b, reshape(view(x, ctr .+ (1:n)), size(b)) ./ sqrt(dim(c)))
+            ctr += n
+        end
+        return t′
+    end
+    return vec_real, from_vec
+end
+FiniteDifferences.to_vec(t::TensorKit.AdjointTensorMap) = to_vec(copy(t))
+
+end


### PR DESCRIPTION
This is mostly to avoid having to redefine this functionality in downstream packages, i.e. in PEPSKit.jl.
See https://github.com/QuantumKitHub/PEPSKit.jl/pull/47