### PR TITLE
New indexing and iteration for ProductSector

### DIFF
--- a/TensorKitSectors/src/auxiliary.jl
+++ b/TensorKitSectors/src/auxiliary.jl
@@ -13,3 +13,77 @@ function _kron(A, B)
     end
     return C
 end
+
+# Manhattan based distance enumeration: t is supposed to be one-based index
+# TODO: is there any way to make this faster?
+@inline function num_manhattan_points(d::Int, sz::Dims{1})
+    return Int(sz[1] > d)
+end
+@inline function num_manhattan_points(d::Int, sz::Dims{N}) where {N}
+    d == 0 && return 1
+    num = 0
+    for i in 1:min(sz[1], d + 1)
+        num += num_manhattan_points(d - i + 1, Base.tail(sz))
+    end
+    return num
+end
+
+@inline localoffset(d, I::Tuple{Int}, sz::Tuple{Int}) = 0
+@inline function localoffset(d, I, sz)
+    offset = 0
+    for i in 1:(I[1] - 1)
+        offset += num_manhattan_points(d - i + 1, Base.tail(sz))
+    end
+    offset += localoffset(d - I[1] + 1, Base.tail(I), Base.tail(sz))
+    return offset
+end
+
+to_manhattan_index(::Tuple{}, ::Tuple{}) = 1
+to_manhattan_index(I::Tuple{Int}, ::Tuple{Int}) = I[1]
+function to_manhattan_index(I::Dims{N}, sz::Dims{N}) where {N}
+    d = sum(I) - N # Manhattan distance to origin for one-based indices
+    d == 0 && return 1
+    index = 1
+    # count all the points with smaller Manhatten distance
+    for k in 0:(d - 1)
+        index += num_manhattan_points(k, sz)
+    end
+    return index + localoffset(d, I, sz)
+end
+
+
+
+@inline invertlocaloffset(d, offset, sz::Tuple{Int}) = (d+1,)
+@inline function invertlocaloffset(d, offset, sz)
+    i₁ = 1
+    while i₁ < sz[1]
+        jump = num_manhattan_points(d - i₁ + 1, Base.tail(sz))
+        if offset < jump
+            break
+        end
+        offset -= jump
+        i₁ += 1
+    end
+    return (i₁, invertlocaloffset(d - i₁ + 1, offset, Base.tail(sz))...)
+end
+
+manhattan_to_multidimensional_index(index::Int, ::Dims{0}) = ()
+manhattan_to_multidimensional_index(index::Int, ::Dims{1}) = (index,)
+function manhattan_to_multidimensional_index(index::Int, sz::Dims{N}) where {N}
+    # find the layer of the Manhattan distance
+    index == 1 && return ntuple(one, Val(N))
+    offset = 1
+    d = 1
+    while true
+        currentlayer = num_manhattan_points(d, sz)
+        if index <= offset + currentlayer
+            break
+        end
+        d += 1
+        offset += currentlayer
+    end
+
+    # find the position within the layer
+    index -= offset
+    return invertlocaloffset(d, index - 1, sz)
+end

--- a/TensorKitSectors/src/auxiliary.jl
+++ b/TensorKitSectors/src/auxiliary.jl
@@ -14,8 +14,10 @@ function _kron(A, B)
     return C
 end
 
-# Manhattan based distance enumeration: t is supposed to be one-based index
+# Manhattan based distance enumeration: I is supposed to be one-based index
 # TODO: is there any way to make this faster?
+
+# forward mapping from multidimensional to single Manhattan index
 @inline function num_manhattan_points(d::Int, sz::Dims{1})
     return Int(sz[1] > d)
 end
@@ -51,9 +53,8 @@ function to_manhattan_index(I::Dims{N}, sz::Dims{N}) where {N}
     return index + localoffset(d, I, sz)
 end
 
-
-
-@inline invertlocaloffset(d, offset, sz::Tuple{Int}) = (d+1,)
+# inverse mapping
+@inline invertlocaloffset(d, offset, sz::Tuple{Int}) = (d + 1,)
 @inline function invertlocaloffset(d, offset, sz)
     i₁ = 1
     while i₁ < sz[1]

--- a/TensorKitSectors/src/product.jl
+++ b/TensorKitSectors/src/product.jl
@@ -45,7 +45,7 @@ function findindex(P::SectorValues{ProductSector{T}},
     return to_manhattan_index(findindex.(values.(_sectors(T)), c.sectors), _size(P))
 end
 
-function Base.iterate(P::SectorValues{ProductSector{T}}, i = 1) where {T<:SectorTuple}
+function Base.iterate(P::SectorValues{ProductSector{T}}, i=1) where {T<:SectorTuple}
     Base.IteratorSize(P) != Base.IsInfinite() && i > length(P) && return nothing
     return getindex(P, i), i + 1
 end

--- a/TensorKitSectors/test/newsectors.jl
+++ b/TensorKitSectors/test/newsectors.jl
@@ -75,4 +75,9 @@ end
 Base.hash(s::NewSU2Irrep, h::UInt) = hash(s.j, h)
 Base.isless(s1::NewSU2Irrep, s2::NewSU2Irrep) = isless(s1.j, s2.j)
 
+function Base.getindex(::SectorValues{NewSU2Irrep}, i::Int)
+    return 1 <= i ? NewSU2Irrep(half(i - 1)) : throw(BoundsError(values(NewSU2Irrep), i))
+end
+TensorKitSectors.findindex(::SectorValues{NewSU2Irrep}, s::NewSU2Irrep) = twice(s.j) + 1
+
 end # module NewSectors

--- a/TensorKitSectors/test/runtests.jl
+++ b/TensorKitSectors/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using TestExtras
 using Random
+# using TensorKit: TensorKitSectors
 using TensorKitSectors
 using TensorOperations
 using Base.Iterators: take, product

--- a/TensorKitSectors/test/sectors.jl
+++ b/TensorKitSectors/test/sectors.jl
@@ -21,25 +21,25 @@ end
     sprev = one(I)
     for (i, s) in enumerate(values(I))
         @test !isless(s, sprev) # confirm compatibility with sort order
-        if Base.IteratorSize(values(I)) == Base.IsInfinite() && I <: ProductSector
-            @test_throws ArgumentError values(I)[i]
-            @test_throws ArgumentError findindex(values(I), s)
-        elseif hasmethod(Base.getindex, Tuple{typeof(values(I)),Int})
+        # if Base.IteratorSize(values(I)) == Base.IsInfinite() && I <: ProductSector
+        #     @test_throws ArgumentError values(I)[i]
+        #     @test_throws ArgumentError findindex(values(I), s)
+        # if hasmethod(Base.getindex, Tuple{typeof(values(I)),Int})
             @test s == @constinferred (values(I)[i])
             @test findindex(values(I), s) == i
-        end
+        # end
         sprev = s
         i >= 10 && break
     end
     @test one(I) == first(values(I))
-    if Base.IteratorSize(values(I)) == Base.IsInfinite() && I <: ProductSector
-        @test_throws ArgumentError findindex(values(I), one(I))
-    elseif hasmethod(Base.getindex, Tuple{typeof(values(I)),Int})
+    # if Base.IteratorSize(values(I)) == Base.IsInfinite() && I <: ProductSector
+    #     @test_throws ArgumentError findindex(values(I), one(I))
+    # if hasmethod(Base.getindex, Tuple{typeof(values(I)),Int})
         @test (@constinferred findindex(values(I), one(I))) == 1
         for s in smallset(I)
             @test (@constinferred values(I)[findindex(values(I), s)]) == s
         end
-    end
+    # end
 end
 if BraidingStyle(I) isa Bosonic && hasfusiontensor(I)
     @testset "Sector $Istr: fusion tensor and F-move and R-move" begin

--- a/TensorKitSectors/test/sectors.jl
+++ b/TensorKitSectors/test/sectors.jl
@@ -21,25 +21,16 @@ end
     sprev = one(I)
     for (i, s) in enumerate(values(I))
         @test !isless(s, sprev) # confirm compatibility with sort order
-        # if Base.IteratorSize(values(I)) == Base.IsInfinite() && I <: ProductSector
-        #     @test_throws ArgumentError values(I)[i]
-        #     @test_throws ArgumentError findindex(values(I), s)
-        # if hasmethod(Base.getindex, Tuple{typeof(values(I)),Int})
-            @test s == @constinferred (values(I)[i])
-            @test findindex(values(I), s) == i
-        # end
+        @test s == @constinferred (values(I)[i])
+        @test findindex(values(I), s) == i
         sprev = s
         i >= 10 && break
     end
     @test one(I) == first(values(I))
-    # if Base.IteratorSize(values(I)) == Base.IsInfinite() && I <: ProductSector
-    #     @test_throws ArgumentError findindex(values(I), one(I))
-    # if hasmethod(Base.getindex, Tuple{typeof(values(I)),Int})
-        @test (@constinferred findindex(values(I), one(I))) == 1
-        for s in smallset(I)
-            @test (@constinferred values(I)[findindex(values(I), s)]) == s
-        end
-    # end
+    @test (@constinferred findindex(values(I), one(I))) == 1
+    for s in smallset(I)
+        @test (@constinferred values(I)[findindex(values(I), s)]) == s
+    end
 end
 if BraidingStyle(I) isa Bosonic && hasfusiontensor(I)
     @testset "Sector $Istr: fusion tensor and F-move and R-move" begin


### PR DESCRIPTION
ProductSector can be indexed and will iterate using an order that is based on running through slices of constant Manhattan distance. This enables indexing and meaningful iteration if infinite sectors are included in the product sector. 