### PR TITLE
Fix `TensorMap` constructor for symmetric tensor from dense matrix

### DIFF
--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -400,9 +400,10 @@ function TensorMap(data::DenseArray, V::TensorMapSpace{S,N₁,N₂};
     end
 
     t = TensorMap{eltype(data)}(undef, codom, dom)
-    project_symmetric!(t, data)
+    data2 = reshape(data, (dims(codom)..., dims(dom)...))
+    project_symmetric!(t, data2)
 
-    if !isapprox(data, convert(Array, t); atol=tol)
+    if !isapprox(data2, convert(Array, t); atol=tol)
         throw(ArgumentError("Data has non-zero elements at incompatible positions"))
     end
 

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -117,7 +117,7 @@ for V in spacelist
                     @test t ≈ @constinferred TensorMap(a, W)
                     # also test if input is matrix
                     a2 = reshape(a, prod(dim, codomain(t)), prod(dim, domain(t)))
-                    @test a2 ≈ @constinferred convert(Array, t, (codomain(t), domain(t)))
+                    @test t ≈ @constinferred TensorMap(a2, codomain(t), domain(t))
                 end
             end
         end

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -115,6 +115,9 @@ for V in spacelist
                     end
                     a = @constinferred convert(Array, t)
                     @test t ≈ @constinferred TensorMap(a, W)
+                    # also test if input is matrix
+                    a2 = reshape(a, prod(dim, codomain(t)), prod(dim, domain(t)))
+                    @test a2 ≈ @constinferred convert(Array, t, (codomain(t), domain(t)))
                 end
             end
         end


### PR DESCRIPTION
This is the first part of fixing issue #143 