### PR TITLE
AdjointTensorMap can wrap generic tensor types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ Features that are planned to be implemented before the release of v1.0.0, in no 
 - [ ] Make `TrivialTensorMap` and `TensorMap` be the same
 - [ ] Simplify `TensorMap` type to hide `rowr` and `colr`
 - [ ] Change block order in `rowr` / `colr` to speed up particular contractions
-- [ ] Make `AdjointTensorMap` generic
+- [x] Make `AdjointTensorMap` generic
 - [ ] Rewrite planar operations in order to be AD-compatible
 - [x] Fix rrules for fermionic tensors
 - [ ] Fix GPU support


### PR DESCRIPTION
This changes the `AdjointTensorMap` type such that it can wrap any `AbstractTensorMap` instead of forcing it to be a `TensorMap` instance.