### PR TITLE
Remove fishy loading of extension in extension

### DIFF
--- a/ext/TensorKitChainRulesCoreExt/TensorKitChainRulesCoreExt.jl
+++ b/ext/TensorKitChainRulesCoreExt/TensorKitChainRulesCoreExt.jl
@@ -11,12 +11,7 @@ import TensorOperations as TO
 using TensorOperations: promote_contract
 using VectorInterface: promote_scale, promote_add
 
-ext = @static if isdefined(Base, :get_extension)
-    Base.get_extension(TensorOperations, :TensorOperationsChainRulesCoreExt)
-else
-    TensorOperations.TensorOperationsChainRulesCoreExt
-end
-const trivtuple = ext.trivtuple
+trivtuple(N) = ntuple(identity, N)
 
 include("utility.jl")
 include("constructors.jl")


### PR DESCRIPTION
this avoids loading TensorOperationsChainRulesCoreExt from within TensorKitChainRulesCoreExt, which seems to lead to issues from julia 1.11.1 onwards

Will backport this to the 0.12 branch after it gets merged.