### PR TITLE
PR review changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,9 +3,9 @@
 Features that are planned to be implemented before the release of v1.0.0, in no particular order.
 
 - [x] Separate `Sectors` module
-- [ ] Make `TrivialTensorMap` and `TensorMap` be the same
-- [ ] Simplify `TensorMap` type to hide `rowr` and `colr`
-- [ ] Change block order in `rowr` / `colr` to speed up particular contractions
+- [x] Make `TrivialTensorMap` and `TensorMap` be the same
+- [x] Simplify `TensorMap` type to hide `rowr` and `colr`
+- [x] Change block order in `rowr` / `colr` to speed up particular contractions
 - [x] Make `AdjointTensorMap` generic
 - [ ] Rewrite planar operations in order to be AD-compatible
 - [x] Fix rrules for fermionic tensors
@@ -47,3 +47,17 @@ as there are some changes in the API.
 
 This promotes TensorKitSectors to its own package, in order to make the dependencies
 lighter and to separate the concerns of the two packages.
+
+### FusionTree vertices
+
+In order to simplify the `FusionTree` struct, we removed the usage of anything other than
+`Int` as a vertex-label when working with `GenericFusion` sectors.
+
+### TensorStructure
+
+This PR changed the data structure of `TensorMap` to consist of a single vector of data,
+where all blocks and subblocks are various views into this object. This entails major
+simplifications for the outwards-facing interface, as now the `TensorMap` type requires less
+parameters, and the fusion-tree structure is more clearly considered as an implementation
+detail that can be left hidden to the user. Various other improvements and documentation
+work was also carried out.

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -1,31 +1,35 @@
 # TensorMap & Tensor:
 # general tensor implementation with arbitrary symmetries
 #==========================================================#
-#! format: off
 """
     struct TensorMap{T, S<:IndexSpace, N₁, N₂, A<:DenseVector{T}} <: AbstractTensorMap{T, S, N₁, N₂}
 
 Specific subtype of [`AbstractTensorMap`](@ref) for representing tensor maps (morphisms in
 a tensor category), where the data is stored in a dense vector.
 """
-struct TensorMap{T, S<:IndexSpace, N₁, N₂, A<:DenseVector{T}} <: AbstractTensorMap{T, S, N₁, N₂}
+struct TensorMap{T,S<:IndexSpace,N₁,N₂,A<:DenseVector{T}} <: AbstractTensorMap{T,S,N₁,N₂}
     data::A
     space::TensorMapSpace{S,N₁,N₂}
-    
+
     # uninitialized constructors
-    function TensorMap{T,S,N₁,N₂,A}(::UndefInitializer, space::TensorMapSpace{S,N₁,N₂}) where {T,S<:IndexSpace,N₁,N₂,A<:DenseVector{T}}
+    function TensorMap{T,S,N₁,N₂,A}(::UndefInitializer,
+                                    space::TensorMapSpace{S,N₁,N₂}) where {T,S<:IndexSpace,
+                                                                           N₁,N₂,
+                                                                           A<:DenseVector{T}}
         d = fusionblockstructure(space).totaldim
         data = A(undef, d)
         return TensorMap{T,S,N₁,N₂,A}(data, space)
     end
-    
+
     # constructors from data
-    function TensorMap{T,S,N₁,N₂,A}(data::A, space::TensorMapSpace{S,N₁,N₂}) where {T,S<:IndexSpace,N₁,N₂,A<:DenseVector{T}}
+    function TensorMap{T,S,N₁,N₂,A}(data::A,
+                                    space::TensorMapSpace{S,N₁,N₂}) where {T,S<:IndexSpace,
+                                                                           N₁,N₂,
+                                                                           A<:DenseVector{T}}
         T ⊆ field(S) || @warn("scalartype(data) = $T ⊈ $(field(S)))", maxlog = 1)
         return new{T,S,N₁,N₂,A}(data, space)
     end
 end
-#! format: on
 
 """
     Tensor{T, S, N, A<:DenseVector{T}} = TensorMap{T, S, N, 0, A}

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -42,9 +42,6 @@ i.e. a tensor map with only a non-trivial output space.
 """
 const Tensor{T,S,N,A} = TensorMap{T,S,N,0,A}
 
-# TODO: should we deprecate this?
-# It seems quite heavily used in MPSKit.jl, although they are all of the form
-# `tensormaptype(S, N₁, N₂, A)` and so could thus be replaced with `TensorMap{S, N₁, N₂, A}`
 function tensormaptype(S::Type{<:IndexSpace}, N₁, N₂, TorA::Type)
     if TorA <: Number
         return TensorMap{TorA,S,N₁,N₂,Vector{TorA}}

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -74,7 +74,8 @@ dim(t::TensorMap) = length(t.data)
     TensorMap{T}(undef, codomain ← domain)
     TensorMap{T}(undef, domain → codomain)
     # expert mode: select storage type `A`
-    TensorMap{T,S,N₁,N₂,A}(undef, codomain::ProductSpace{S,N₁}, domain::ProductSpace{S,N₂})
+    TensorMap{T,S,N₁,N₂,A}(undef, codomain ← domain)
+    TensorMap{T,S,N₁,N₂,A}(undef, domain → domain)
 
 Construct a `TensorMap` with uninitialized data.
 """


### PR DESCRIPTION
Added some minor changes I found while browsing through the PR:
- Updated the changelog
- Re-enabled formatting the `TensorMap` struct definition
- Changed a docstring to reflect that the fully typed `TensorMap{E,S,N1,N2,A}` requires homspaces, not two productspace arguments