### PR TITLE
Treetransformer optimizations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "TensorKit"
 uuid = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 authors = ["Jutho Haegeman"]
-version = "0.13"
+version = "0.13.0"
 
 [deps]
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 TensorKitSectors = "13a9c161-d5da-41f0-bcbd-e1a08ae0647f"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
@@ -32,6 +33,7 @@ LRUCache = "1.0.2"
 LinearAlgebra = "1"
 PackageExtensionCompat = "1"
 Random = "1"
+SparseArrays = "1"
 Strided = "2"
 TensorKitSectors = "0.1"
 TensorOperations = "5.1"

--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -119,6 +119,9 @@ using LinearAlgebra: norm, dot, normalize, normalize!, tr,
                      eigen, eigen!, svd, svd!,
                      isposdef, isposdef!, ishermitian,
                      Diagonal, Hermitian
+
+using SparseArrays: SparseMatrixCSC, sparse, nzrange, rowvals, nonzeros
+
 import Base.Meta
 
 using Random: Random
@@ -185,6 +188,7 @@ include("tensors/adjoint.jl")
 include("tensors/linalg.jl")
 include("tensors/vectorinterface.jl")
 include("tensors/tensoroperations.jl")
+include("tensors/treetransformers.jl")
 include("tensors/indexmanipulations.jl")
 include("tensors/truncation.jl")
 include("tensors/factorizations.jl")

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -35,6 +35,10 @@ spacetype(::Type{<:HomSpace{S}}) where {S} = S
 field(L::Type{<:HomSpace}) = field(spacetype(L))
 sectortype(L::Type{<:HomSpace}) = sectortype(spacetype(L))
 
+numout(W::HomSpace) = length(codomain(W))
+numin(W::HomSpace) = length(domain(W))
+numind(W::HomSpace) = numin(W) + numout(W)
+
 const TensorSpace{S<:ElementarySpace} = Union{S,ProductSpace{S}}
 const TensorMapSpace{S<:ElementarySpace,N₁,N₂} = HomSpace{S,ProductSpace{S,N₁},
                                                           ProductSpace{S,N₂}}

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -273,12 +273,12 @@ the indices of `tsrc` according to `(p₁, p₂)`.
 
 See also [`permute`](@ref), [`permute!`](@ref), [`add_braid!`](@ref), [`add_transpose!`](@ref).
 """
-@propagate_inbounds function add_permute!(tdst::AbstractTensorMap{T,S,N₁,N₂},
+@propagate_inbounds function add_permute!(tdst::AbstractTensorMap,
                                           tsrc::AbstractTensorMap,
-                                          p::Index2Tuple{N₁,N₂},
+                                          p::Index2Tuple,
                                           α::Number,
                                           β::Number,
-                                          backend::AbstractBackend...) where {T,S,N₁,N₂}
+                                          backend::AbstractBackend...)
     transformer = treepermuter(tdst, tsrc, p)
     return add_transform!(tdst, tsrc, p, transformer, α, β, backend...)
 end
@@ -292,13 +292,13 @@ the indices of `tsrc` according to `(p₁, p₂)` and `levels`.
 
 See also [`braid`](@ref), [`braid!`](@ref), [`add_permute!`](@ref), [`add_transpose!`](@ref).
 """
-@propagate_inbounds function add_braid!(tdst::AbstractTensorMap{T,S,N₁,N₂},
+@propagate_inbounds function add_braid!(tdst::AbstractTensorMap,
                                         tsrc::AbstractTensorMap,
-                                        p::Index2Tuple{N₁,N₂},
+                                        p::Index2Tuple,
                                         levels::IndexTuple,
                                         α::Number,
                                         β::Number,
-                                        backend::AbstractBackend...) where {T,S,N₁,N₂}
+                                        backend::AbstractBackend...)
     length(levels) == numind(tsrc) ||
         throw(ArgumentError("incorrect levels $levels for tensor map $(codomain(tsrc)) ← $(domain(tsrc))"))
 
@@ -318,12 +318,12 @@ the indices of `tsrc` according to `(p₁, p₂)`.
 
 See also [`transpose`](@ref), [`transpose!`](@ref), [`add_permute!`](@ref), [`add_braid!`](@ref).
 """
-@propagate_inbounds function add_transpose!(tdst::AbstractTensorMap{T,S,N₁,N₂},
+@propagate_inbounds function add_transpose!(tdst::AbstractTensorMap,
                                             tsrc::AbstractTensorMap,
-                                            p::Index2Tuple{N₁,N₂},
+                                            p::Index2Tuple,
                                             α::Number,
                                             β::Number,
-                                            backend::AbstractBackend...) where {T,S,N₁,N₂}
+                                            backend::AbstractBackend...)
     transformer = treetransposer(tdst, tsrc, p)
     return add_transform!(tdst, tsrc, p, transformer, α, β, backend...)
 end

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -436,7 +436,7 @@ function catcodomain(t1::TT, t2::TT) where {S,N₂,TT<:AbstractTensorMap{<:Any,S
     V = V1 ⊕ V2
     T = promote_type(scalartype(t1), scalartype(t2))
     t = similar(t1, T, V ← domain(t1))
-    for (c, b) in sectors(t)
+    for (c, b) in blocks(t)
         b[1:dim(V1, c), :] .= block(t1, c)
         b[dim(V1, c) .+ (1:dim(V2, c)), :] .= block(t2, c)
     end

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -453,9 +453,7 @@ column indices correspond to `f₂.uncoupled`.
     @inbounds begin
         i = structure.fusiontreeindices[(f₁, f₂)]
         sz, str, offset = structure.fusiontreestructure[i]
-        subblock = StridedView(t.data, sz, str, offset)
-        d = (dims(codomain(t), f₁.uncoupled)..., dims(domain(t), f₂.uncoupled)...)
-        return sreshape(subblock, d)
+        return StridedView(t.data, sz, str, offset)
     end
 end
 # The following is probably worth special casing for trivial tensors

--- a/src/tensors/treetransformers.jl
+++ b/src/tensors/treetransformers.jl
@@ -1,0 +1,123 @@
+"""
+    TreeTransformer
+
+Supertype for structures containing the data for a tree transformation.
+"""
+abstract type TreeTransformer end
+
+function treetransformertype(Vdst, Vsrc)
+    I = sectortype(Vdst)
+    N = numind(Vdst)
+    F1 = fusiontreetype(I, numout(Vdst))
+    F2 = fusiontreetype(I, numin(Vdst))
+    F3 = fusiontreetype(I, numout(Vsrc))
+    F4 = fusiontreetype(I, numin(Vsrc))
+    return GenericTreeTransformer{sectorscalartype(I),I,N,F1,F2,F3,F4}
+end
+
+struct GenericTreeTransformer{T,I,N,F1,F2,F3,F4} <: TreeTransformer
+    matrix::SparseMatrixCSC{T,Int}
+    structure_dst::FusionBlockStructure{I,N,F1,F2}
+    structure_src::FusionBlockStructure{I,N,F3,F4}
+end
+
+function GenericTreeTransformer(transform::Function, Vsrc::HomSpace, Vdst::HomSpace)
+    structure_dst = fusionblockstructure(Vdst)
+    structure_src = fusionblockstructure(Vsrc)
+
+    ldst = length(structure_dst.fusiontreelist)
+    lsrc = length(structure_src.fusiontreelist)
+
+    rows = Int[]
+    cols = Int[]
+    vals = sectorscalartype(sectortype(Vdst))[]
+
+    for (f1, f2) in structure_src.fusiontreelist
+        row = structure_src.fusiontreeindices[(f1, f2)]
+        for ((f3, f4), coeff) in transform(f1, f2)
+            col = structure_dst.fusiontreeindices[(f3, f4)]
+            push!(rows, row)
+            push!(cols, col)
+            push!(vals, coeff)
+        end
+    end
+    matrix = sparse(rows, cols, vals, ldst, lsrc)
+
+    return GenericTreeTransformer(matrix, structure_dst, structure_src)
+end
+
+# Transpose
+# ---------
+const treetransposercache = LRU{Any,Any}(; maxsize=10^5)
+const usetreetransposercache = Ref{Bool}(true)
+
+function treetransposer(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, p::Index2Tuple)
+    if usetreetransposercache[]
+        key = (space(tdst), space(tsrc), p)
+        A = treetransformertype(space(tdst), space(tsrc))
+        return _get_treetransposer(A, key)
+    else
+        return _treetransposer((space(tdst), space(tsrc), p))
+    end
+end
+@noinline function _get_treetransposer(A, key)
+    d::A = get!(treetransposercache, key) do
+        return _treetransposer(key)
+    end
+    return d
+end
+function _treetransposer((Vdst, Vsrc, p))
+    fusiontreetransform(f1, f2) = transpose(f1, f2, p...)
+    return GenericTreeTransformer(fusiontreetransform, Vsrc, Vdst)
+end
+
+# Braid
+# -----
+const treebraidercache = LRU{Any,Any}(; maxsize=10^5)
+const usetreebraidercache = Ref{Bool}(true)
+
+function treebraider(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, p::Index2Tuple,
+                     l::Index2Tuple)
+    if usetreebraidercache[]
+        key = (space(tdst), space(tsrc), p, l)
+        A = treetransformertype(space(tdst), space(tsrc))
+        return _get_treebraider(A, key)
+    else
+        return _treebraider((space(tdst), space(tsrc), p, l))
+    end
+end
+@noinline function _get_treebraider(A, key)
+    d::A = get!(treebraidercache, key) do
+        return _treebraider(key)
+    end
+    return d
+end
+function _treebraider((Vdst, Vsrc, p, l))
+    fusiontreetransform(f1, f2) = braid(f1, f2, p..., l...)
+    return GenericTreeTransformer(fusiontreetransform, Vsrc, Vdst)
+end
+
+# Permute
+# -------
+const treepermutercache = LRU{Any,Any}(; maxsize=10^5)
+const usetreepermutercache = Ref{Bool}(true)
+
+function treepermuter(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, p::Index2Tuple)
+    if usetreepermutercache[]
+        key = (space(tdst), space(tsrc), p)
+        A = treetransformertype(space(tdst), space(tsrc))
+        return _get_treepermuter(A, key)
+    else
+        return _treepermuter((space(tdst), space(tsrc), p))
+    end
+end
+@noinline function _get_treepermuter(A, key)
+    d::A = get!(treepermutercache, key) do
+        return _treepermuter(key)
+    end
+    return d
+end
+function _treepermuter((Vdst, Vsrc, p))
+    fusiontreetransform(f1, f2) = permute(f1, f2, p...)
+    return GenericTreeTransformer(fusiontreetransform, Vsrc, Vdst)
+end

--- a/src/tensors/treetransformers.jl
+++ b/src/tensors/treetransformers.jl
@@ -75,7 +75,10 @@ end
 const treetransposercache = LRU{Any,Any}(; maxsize=10^5)
 const usetreetransposercache = Ref{Bool}(true)
 
-function treetransposer(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, p::Index2Tuple)
+function treetransposer(::AbstractTensorMap, ::AbstractTensorMap, p::Index2Tuple)
+    return fusiontreetransform(f1, f2) = transpose(f1, f2, p...)
+end
+function treetransposer(tdst::TensorMap, tsrc::TensorMap, p::Index2Tuple)
     if usetreetransposercache[]
         key = (space(tdst), space(tsrc), p)
         A = treetransformertype(space(tdst), space(tsrc))
@@ -100,7 +103,11 @@ end
 const treebraidercache = LRU{Any,Any}(; maxsize=10^5)
 const usetreebraidercache = Ref{Bool}(true)
 
-function treebraider(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, p::Index2Tuple,
+function treebraider(::AbstractTensorMap, ::AbstractTensorMap, p::Index2Tuple,
+                     l::Index2Tuple)
+    return fusiontreetransform(f1, f2) = braid(f1, f2, p..., l...)
+end
+function treebraider(tdst::TensorMap, tsrc::TensorMap, p::Index2Tuple,
                      l::Index2Tuple)
     if usetreebraidercache[]
         key = (space(tdst), space(tsrc), p, l)
@@ -126,7 +133,10 @@ end
 const treepermutercache = LRU{Any,Any}(; maxsize=10^5)
 const usetreepermutercache = Ref{Bool}(true)
 
-function treepermuter(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, p::Index2Tuple)
+function treepermuter(::AbstractTensorMap, ::AbstractTensorMap, p::Index2Tuple)
+    return fusiontreetransform(f1, f2) = permute(f1, f2, p...)
+end
+function treepermuter(tdst::TensorMap, tsrc::TensorMap, p::Index2Tuple)
     if usetreepermutercache[]
         key = (space(tdst), space(tsrc), p)
         A = treetransformertype(space(tdst), space(tsrc))


### PR DESCRIPTION
This PR refactors some of the structure code to obtain a (hopefully) faster kernel for the `add_transform!` implementation.
The main changes are that the cached structures now immediately return the correct strides and sizes, and the kernels make use of that feature, and avoid all dictionary lookups.
I also made sure to loop over the destination subblocks first, such that this should be more convenient to allow for multithreaded approaches.

We might want to consider merging that other PR first, and just merging this straight to master...

## TODO
- [x] abelian specialization
- [ ] adjoint specialization
- [ ] multithreaded experiments
- [ ] benchmarks