### PR TITLE
`insertleftunit`, `insertrightunit` and `removeunit`

### DIFF
--- a/docs/src/lib/spaces.md
+++ b/docs/src/lib/spaces.md
@@ -106,7 +106,6 @@ fuse
 ismonomorphic
 isepimorphic
 isisomorphic
-insertunit
 ```
 
 There are also specific methods for `HomSpace` instances, that are used in determining
@@ -116,4 +115,6 @@ the resuling `HomSpace` after applying certain tensor operations.
 TensorKit.permute(::HomSpace{S}, ::Index2Tuple{N₁,N₂}) where {S,N₁,N₂}
 TensorKit.select(::HomSpace{S}, ::Index2Tuple{N₁,N₂}) where {S,N₁,N₂}
 TensorKit.compose(::HomSpace{S}, ::HomSpace{S}) where {S}
+insertleftunit(::HomSpace, ::Int)
+insertrightunit(::HomSpace, ::Int)
 ```

--- a/docs/src/lib/tensors.md
+++ b/docs/src/lib/tensors.md
@@ -175,6 +175,8 @@ braid(::AbstractTensorMap, ::Index2Tuple, ::IndexTuple; ::Bool)
 transpose(::AbstractTensorMap, ::Index2Tuple; ::Bool)
 repartition(::AbstractTensorMap, ::Int, ::Int; ::Bool)
 twist(::AbstractTensorMap, ::Int; ::Bool)
+insertleftunit(::AbstractTensorMap, ::Int)
+insertrightunit(::AbstractTensorMap, ::Int)
 ```
 
 ```@docs

--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -31,8 +31,8 @@ export TruncationScheme
 export SpaceMismatch, SectorMismatch, IndexError # error types
 
 # general vector space methods
-export space, field, dual, dim, reduceddim, dims, fuse, flip, isdual, insertunit,
-       removeunit, oplus
+export space, field, dual, dim, reduceddim, dims, fuse, flip, isdual, oplus,
+       insertleftunit, insertrightunit, removeunit
 
 # partial order for vector spaces
 export infimum, supremum, isisomorphic, ismonomorphic, isepimorphic

--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -31,7 +31,8 @@ export TruncationScheme
 export SpaceMismatch, SectorMismatch, IndexError # error types
 
 # general vector space methods
-export space, field, dual, dim, reduceddim, dims, fuse, flip, isdual, insertunit, oplus
+export space, field, dual, dim, reduceddim, dims, fuse, flip, isdual, insertunit,
+       removeunit, oplus
 
 # partial order for vector spaces
 export infimum, supremum, isisomorphic, ismonomorphic, isepimorphic

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -41,6 +41,9 @@ function _kron(A, B)
     return C
 end
 
+@noinline _boundserror(P, i) = throw(BoundsError(P, i))
+@noinline _nontrivialspaceerror(P, i) = throw(ArgumentError(lazy"Attempting to remove a non-trivial space $(P[i])"))
+
 # Compat implementation:
 @static if VERSION < v"1.7"
     macro constprop(setting, ex)

--- a/src/auxiliary/deprecate.jl
+++ b/src/auxiliary/deprecate.jl
@@ -56,4 +56,6 @@ end
 
 Base.@deprecate EuclideanProduct() EuclideanInnerProduct()
 
+Base.@deprecate insertunit(P::ProductSpace, args...; kwargs...) insertleftunit(args...; kwargs...)
+
 #! format: on

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -197,6 +197,24 @@ Base.@constprop :aggressive function insertunit(W::HomSpace, i::Int=numind(W) + 
     end
 end
 
+"""
+    removeunit(P::HomSpace, i::Int)
+
+This removes a trivial tensor product factor at position `1 ≤ i ≤ N`.
+For this to work, that factor has to be isomorphic to the field of scalars.
+
+This operation undoes the work of [`insertunit`](@ref).
+"""
+function removeunit(P::HomSpace, i::Int)
+    if i in 1:numout(P)
+        return removeunit(codomain(P), i) ← domain(P)
+    elseif i in (numout(P) + 1):numind(P)
+        return codomain(P) ← removeunit(domain(P), i - numout(P))
+    else
+        throw(BoundsError(P, i))
+    end
+end
+
 # Block and fusion tree ranges: structure information for building tensors
 #--------------------------------------------------------------------------
 struct FusionBlockStructure{I,N,F₁,F₂}

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -182,8 +182,8 @@ More specifically, adds a left monoidal unit or its dual.
 
 See also [`insertrightunit`](@ref), [`removeunit`](@ref).
 """
-function insertleftunit(W::HomSpace, i::Int=numind(W) + 1;
-                        conj::Bool=false, dual::Bool=false)
+@constprop :aggressive function insertleftunit(W::HomSpace, i::Int=numind(W) + 1;
+                                               conj::Bool=false, dual::Bool=false)
     if i ≤ numout(W)
         return insertleftunit(codomain(W), i; conj, dual) ← domain(W)
     else
@@ -199,8 +199,8 @@ More specifically, adds a right monoidal unit or its dual.
 
 See also [`insertleftunit`](@ref), [`removeunit`](@ref).
 """
-function insertrightunit(W::HomSpace, i::Int=numind(W);
-                         conj::Bool=false, dual::Bool=false)
+@constprop :aggressive function insertrightunit(W::HomSpace, i::Int=numind(W);
+                                                conj::Bool=false, dual::Bool=false)
     if i ≤ numout(W)
         return insertrightunit(codomain(W), i; conj, dual) ← domain(W)
     else
@@ -216,7 +216,7 @@ For this to work, that factor has to be isomorphic to the field of scalars.
 
 This operation undoes the work of [`insertleftunit`](@ref) or [`insertrightunit`](@ref).
 """
-function removeunit(P::HomSpace, i::Int)
+@constprop :aggressive function removeunit(P::HomSpace, i::Int)
     if i ≤ numout(P)
         return removeunit(codomain(P), i) ← domain(P)
     else

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -174,6 +174,29 @@ function compose(W::HomSpace{S}, V::HomSpace{S}) where {S}
     return HomSpace(codomain(W), domain(V))
 end
 
+"""
+    insertunit(W::HomSpace, i::Int=ndims(W) + 1; conj=false, dual=false, preferdomain=false)
+
+Insert a trivial vector space, isomorphic to the underlying field, at position `i`.
+Whenever `i == numout(W)`, the ambiguity to determine whether this space is added in the domain or
+codomain is controlled by `preferdomain`.
+"""
+Base.@constprop :aggressive function insertunit(W::HomSpace, i::Int=numind(W) + 1;
+                                                conj::Bool=false, dual::Bool=false,
+                                                preferdomain::Bool=false)
+    if i ≤ numout(W)
+        return insertunit(codomain(W), i; conj, dual) ← domain(W)
+    elseif i == numout(W) + 1
+        if preferdomain
+            return codomain(W) ← insertunit(domain(W), 1; conj, dual)
+        else
+            return insertunit(codomain(W); conj, dual) ← domain(W)
+        end
+    else
+        return codomain(W) ← insertunit(domain(W), i - numout(W); conj, dual)
+    end
+end
+
 # Block and fusion tree ranges: structure information for building tensors
 #--------------------------------------------------------------------------
 struct FusionBlockStructure{I,N,F₁,F₂}

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -175,25 +175,36 @@ function compose(W::HomSpace{S}, V::HomSpace{S}) where {S}
 end
 
 """
-    insertunit(W::HomSpace, i::Int=ndims(W) + 1; conj=false, dual=false, preferdomain=false)
+    insertleftunit(W::HomSpace, i::Int=numind(W) + 1; conj=false, dual=false)
 
 Insert a trivial vector space, isomorphic to the underlying field, at position `i`.
-Whenever `i == numout(W)`, the ambiguity to determine whether this space is added in the domain or
-codomain is controlled by `preferdomain`.
+More specifically, adds a left monoidal unit or its dual.
+
+See also [`insertrightunit`](@ref), [`removeunit`](@ref).
 """
-Base.@constprop :aggressive function insertunit(W::HomSpace, i::Int=numind(W) + 1;
-                                                conj::Bool=false, dual::Bool=false,
-                                                preferdomain::Bool=false)
+function insertleftunit(W::HomSpace, i::Int=numind(W) + 1;
+                        conj::Bool=false, dual::Bool=false)
     if i ≤ numout(W)
-        return insertunit(codomain(W), i; conj, dual) ← domain(W)
-    elseif i == numout(W) + 1
-        if preferdomain
-            return codomain(W) ← insertunit(domain(W), 1; conj, dual)
-        else
-            return insertunit(codomain(W); conj, dual) ← domain(W)
-        end
+        return insertleftunit(codomain(W), i; conj, dual) ← domain(W)
     else
-        return codomain(W) ← insertunit(domain(W), i - numout(W); conj, dual)
+        return codomain(W) ← insertleftunit(domain(W), i - numout(W); conj, dual)
+    end
+end
+
+"""
+    insertrightunit(W::HomSpace, i::Int=numind(W); conj=false, dual=false)
+
+Insert a trivial vector space, isomorphic to the underlying field, after position `i`.
+More specifically, adds a right monoidal unit or its dual.
+
+See also [`insertleftunit`](@ref), [`removeunit`](@ref).
+"""
+function insertrightunit(W::HomSpace, i::Int=numind(W);
+                         conj::Bool=false, dual::Bool=false)
+    if i ≤ numout(W)
+        return insertrightunit(codomain(W), i; conj, dual) ← domain(W)
+    else
+        return codomain(W) ← insertrightunit(domain(W), i - numout(W); conj, dual)
     end
 end
 
@@ -203,7 +214,7 @@ end
 This removes a trivial tensor product factor at position `1 ≤ i ≤ N`.
 For this to work, that factor has to be isomorphic to the field of scalars.
 
-This operation undoes the work of [`insertunit`](@ref).
+This operation undoes the work of [`insertleftunit`](@ref) or [`insertrightunit`](@ref).
 """
 function removeunit(P::HomSpace, i::Int)
     if i in 1:numout(P)

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -217,12 +217,10 @@ For this to work, that factor has to be isomorphic to the field of scalars.
 This operation undoes the work of [`insertleftunit`](@ref) or [`insertrightunit`](@ref).
 """
 function removeunit(P::HomSpace, i::Int)
-    if i in 1:numout(P)
+    if i ≤ numout(P)
         return removeunit(codomain(P), i) ← domain(P)
-    elseif i in (numout(P) + 1):numind(P)
-        return codomain(P) ← removeunit(domain(P), i - numout(P))
     else
-        throw(BoundsError(P, i))
+        return codomain(P) ← removeunit(domain(P), i - numout(P))
     end
 end
 

--- a/src/spaces/productspace.jl
+++ b/src/spaces/productspace.jl
@@ -253,7 +253,8 @@ More specifically, adds a left monoidal unit or its dual.
 
 See also [`insertrightunit`](@ref), [`removeunit`](@ref).
 """
-function insertleftunit(P::ProductSpace, i::Int=length(P) + 1; kwargs...)
+function insertleftunit(P::ProductSpace, i::Int=length(P) + 1;
+                        conj::Bool=false, dual::Bool=false)
     u = oneunit(spacetype(P))
     if dual
         u = TensorKit.dual(u)
@@ -272,7 +273,8 @@ More specifically, adds a right monoidal unit or its dual.
 
 See also [`insertleftunit`](@ref), [`removeunit`](@ref).
 """
-function insertrightunit(P::ProductSpace, i::Int=length(P); kwargs...)
+function insertrightunit(P::ProductSpace, i::Int=length(P);
+                         conj::Bool=false, dual::Bool=false)
     u = oneunit(spacetype(P))
     if dual
         u = TensorKit.dual(u)

--- a/src/spaces/productspace.jl
+++ b/src/spaces/productspace.jl
@@ -246,17 +246,14 @@ fuse(P::ProductSpace{S,0}) where {S<:ElementarySpace} = oneunit(S)
 fuse(P::ProductSpace{S}) where {S<:ElementarySpace} = fuse(P.spaces...)
 
 """
-    insertunit(P::ProductSpace, i::Int = length(P)+1; dual = false, conj = false)
+    insertleftunit(P::ProductSpace, i::Int=length(P) + 1; conj=false, dual=false)
 
-For `P::ProductSpace{S,N}`, this adds an extra tensor product factor at position
-`1 <= i <= N+1` (last position by default) which is just the `S`-equivalent of the
-underlying field of scalars, i.e. `oneunit(S)`. With the keyword arguments, one can choose
-to insert the conjugated or dual space instead, which are all isomorphic to the field of
-scalars.
+Insert a trivial vector space, isomorphic to the underlying field, at position `i`.
+More specifically, adds a left monoidal unit or its dual.
 
-This operation can be undone by [`removeunit`](@ref).
+See also [`insertrightunit`](@ref), [`removeunit`](@ref).
 """
-function insertunit(P::ProductSpace, i::Int=length(P) + 1; dual=false, conj=false)
+function insertleftunit(P::ProductSpace, i::Int=length(P) + 1; kwargs...)
     u = oneunit(spacetype(P))
     if dual
         u = TensorKit.dual(u)
@@ -265,6 +262,25 @@ function insertunit(P::ProductSpace, i::Int=length(P) + 1; dual=false, conj=fals
         u = TensorKit.conj(u)
     end
     return ProductSpace(TupleTools.insertafter(P.spaces, i - 1, (u,)))
+end
+
+"""
+    insertrightunit(P::ProductSpace, i::Int=lenght(P); conj=false, dual=false)
+
+Insert a trivial vector space, isomorphic to the underlying field, after position `i`.
+More specifically, adds a right monoidal unit or its dual.
+
+See also [`insertleftunit`](@ref), [`removeunit`](@ref).
+"""
+function insertrightunit(P::ProductSpace, i::Int=length(P); kwargs...)
+    u = oneunit(spacetype(P))
+    if dual
+        u = TensorKit.dual(u)
+    end
+    if conj
+        u = TensorKit.conj(u)
+    end
+    return ProductSpace(TupleTools.insertafter(P.spaces, i, (u,)))
 end
 
 """

--- a/src/spaces/productspace.jl
+++ b/src/spaces/productspace.jl
@@ -253,6 +253,8 @@ For `P::ProductSpace{S,N}`, this adds an extra tensor product factor at position
 underlying field of scalars, i.e. `oneunit(S)`. With the keyword arguments, one can choose
 to insert the conjugated or dual space instead, which are all isomorphic to the field of
 scalars.
+
+This operation can be undone by [`removeunit`](@ref).
 """
 function insertunit(P::ProductSpace, i::Int=length(P) + 1; dual=false, conj=false)
     u = oneunit(spacetype(P))
@@ -263,6 +265,21 @@ function insertunit(P::ProductSpace, i::Int=length(P) + 1; dual=false, conj=fals
         u = TensorKit.conj(u)
     end
     return ProductSpace(TupleTools.insertafter(P.spaces, i - 1, (u,)))
+end
+
+"""
+    removeunit(P::ProductSpace, i::Int)
+
+This removes a trivial tensor product factor at position `1 ≤ i ≤ N`.
+For this to work, that factor has to be isomorphic to the field of scalars.
+
+This operation undoes the work of [`insertunit`](@ref).
+"""
+function removeunit(P::ProductSpace, i::Int)
+    1 ≤ i ≤ length(P) || throw(BoundsError(P, i))
+    isisomorphic(P[i], oneunit(P[i])) ||
+        throw(ArgumentError("Attempting to remove a non-trivial space $(P[i])"))
+    return ProductSpace{spacetype(P)}(TupleTools.deleteat(P.spaces, i))
 end
 
 # Functionality for extracting and iterating over spaces

--- a/src/spaces/productspace.jl
+++ b/src/spaces/productspace.jl
@@ -294,9 +294,8 @@ For this to work, that factor has to be isomorphic to the field of scalars.
 This operation undoes the work of [`insertunit`](@ref).
 """
 function removeunit(P::ProductSpace, i::Int)
-    1 ≤ i ≤ length(P) || throw(BoundsError(P, i))
-    isisomorphic(P[i], oneunit(P[i])) ||
-        throw(ArgumentError("Attempting to remove a non-trivial space $(P[i])"))
+    1 ≤ i ≤ length(P) || _boundserror(P, i)
+    isisomorphic(P[i], oneunit(P[i])) || _nontrivialspaceerror(P, i)
     return ProductSpace{spacetype(P)}(TupleTools.deleteat(P.spaces, i))
 end
 

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -292,6 +292,33 @@ See [`twist!`](@ref) for storing the result in place.
 """
 twist(t::AbstractTensorMap, i; inv::Bool=false) = twist!(copy(t), i; inv)
 
+"""
+    insertunit(tsrc::AbstractTensorMap, i::Int=numind(t) + 1;
+               conj=false, dual=false, preferdomain=false, copy=false) -> tdst
+
+Insert a trivial vector space, isomorphic to the underlying field, at position `i`.
+Whenever `i == numout(W)`, the ambiguity to determine whether this space is added in the domain or
+codomain is controlled by `preferdomain`.
+
+If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwise, a copy is always made.
+"""
+function insertunit(t::TensorMap, i::Int=numind(t) + 1;
+                    conj::Bool=false, dual::Bool=false, preferdomain::Bool=false,
+                    copy::Bool=false)
+    W = insertunit(space(t), i; conj, dual, preferdomain)
+    return TensorMap{scalartype(t)}(copy ? Base.copy(t.data) : t.data, W)
+end
+function insertunit(t::AbstractTensorMap, i::Int=numind(t) + 1;
+                    conj::Bool=false, dual::Bool=false, preferdomain::Bool=false,
+                    copy::Bool=true)
+    W = insertunit(space(t), i; conj, dual, preferdomain)
+    tdst = similar(t, W)
+    for (c, b) in blocks(t)
+        copy!(block(tdst, c), b)
+    end
+    return tdst
+end
+
 # Fusing and splitting
 # TODO: add functionality for easy fusing and splitting of tensor indices
 

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -329,11 +329,12 @@ If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwis
 
 This operation undoes the work of [`insertunit`](@ref).
 """
-function removeunit(t::TensorMap, i::Int; copy::Bool=false)
+Base.@constprop :aggressive function removeunit(t::TensorMap, i::Int; copy::Bool=false)
     W = removeunit(space(t), i)
     return TensorMap{scalartype(t)}(copy ? Base.copy(t.data) : t.data, W)
 end
-function removeunit(t::AbstractTensorMap, i::Int=numind(t) + 1; copy::Bool=true)
+Base.@constprop :aggressive function removeunit(t::AbstractTensorMap, i::Int;
+                                                copy::Bool=true)
     W = removeunit(space(t), i)
     tdst = similar(t, W)
     for (c, b) in blocks(t)

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -303,9 +303,9 @@ If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwis
 
 See also [`insertrightunit`](@ref) and [`removeunit`](@ref).
 """
-Base.@constprop :aggressive function insertleftunit(t::AbstractTensorMap,
-                                                    i::Int=numind(t) + 1; copy::Bool=true,
-                                                    conj::Bool=false, dual::Bool=false)
+@constprop :aggressive function insertleftunit(t::AbstractTensorMap,
+                                               i::Int=numind(t) + 1; copy::Bool=true,
+                                               conj::Bool=false, dual::Bool=false)
     W = insertleftunit(space(t), i; conj, dual)
     tdst = similar(t, W)
     for (c, b) in blocks(t)
@@ -313,9 +313,9 @@ Base.@constprop :aggressive function insertleftunit(t::AbstractTensorMap,
     end
     return tdst
 end
-Base.@constprop :aggressive function insertleftunit(t::TensorMap, i::Int=numind(t) + 1;
-                                                    copy::Bool=false,
-                                                    conj::Bool=false, dual::Bool=false)
+@constprop :aggressive function insertleftunit(t::TensorMap, i::Int=numind(t) + 1;
+                                               copy::Bool=false,
+                                               conj::Bool=false, dual::Bool=false)
     W = insertleftunit(space(t), i; conj, dual)
     return TensorMap{scalartype(t)}(copy ? Base.copy(t.data) : t.data, W)
 end
@@ -331,8 +331,8 @@ If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwis
 
 See also [`insertleftunit`](@ref) and [`removeunit`](@ref).
 """
-Base.@constprop :aggressive function insertrightunit(t::AbstractTensorMap, i::Int=numind(t);
-                                                     copy::Bool=true, kwargs...)
+@constprop :aggressive function insertrightunit(t::AbstractTensorMap, i::Int=numind(t);
+                                                copy::Bool=true, kwargs...)
     W = insertrightunit(space(t), i; kwargs...)
     tdst = similar(t, W)
     for (c, b) in blocks(t)
@@ -340,8 +340,8 @@ Base.@constprop :aggressive function insertrightunit(t::AbstractTensorMap, i::In
     end
     return tdst
 end
-Base.@constprop :aggressive function insertrightunit(t::TensorMap, i::Int=numind(t);
-                                                     copy::Bool=false, kwargs...)
+@constprop :aggressive function insertrightunit(t::TensorMap, i::Int=numind(t);
+                                                copy::Bool=false, kwargs...)
     W = insertrightunit(space(t), i; kwargs...)
     return TensorMap{scalartype(t)}(copy ? Base.copy(t.data) : t.data, W)
 end
@@ -356,12 +356,12 @@ If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwis
 
 This operation undoes the work of [`insertunit`](@ref).
 """
-Base.@constprop :aggressive function removeunit(t::TensorMap, i::Int; copy::Bool=false)
+@constprop :aggressive function removeunit(t::TensorMap, i::Int; copy::Bool=false)
     W = removeunit(space(t), i)
     return TensorMap{scalartype(t)}(copy ? Base.copy(t.data) : t.data, W)
 end
-Base.@constprop :aggressive function removeunit(t::AbstractTensorMap, i::Int;
-                                                copy::Bool=true)
+@constprop :aggressive function removeunit(t::AbstractTensorMap, i::Int;
+                                           copy::Bool=true)
     W = removeunit(space(t), i)
     tdst = similar(t, W)
     for (c, b) in blocks(t)

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -319,6 +319,29 @@ function insertunit(t::AbstractTensorMap, i::Int=numind(t) + 1;
     return tdst
 end
 
+"""
+    removeunit(tsrc::AbstractTensorMap, i::Int; copy=false) -> tdst
+
+This removes a trivial tensor product factor at position `1 ≤ i ≤ N`.
+For this to work, that factor has to be isomorphic to the field of scalars.
+
+If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwise, a copy is always made.
+
+This operation undoes the work of [`insertunit`](@ref).
+"""
+function removeunit(t::TensorMap, i::Int; copy::Bool=false)
+    W = removeunit(space(t), i)
+    return TensorMap{scalartype(t)}(copy ? Base.copy(t.data) : t.data, W)
+end
+function removeunit(t::AbstractTensorMap, i::Int=numind(t) + 1; copy::Bool=true)
+    W = removeunit(space(t), i)
+    tdst = similar(t, W)
+    for (c, b) in blocks(t)
+        copy!(block(tdst, c), b)
+    end
+    return tdst
+end
+
 # Fusing and splitting
 # TODO: add functionality for easy fusing and splitting of tensor indices
 

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -278,7 +278,9 @@ println("------------------------------------")
         @test @constinferred(⊗(V1 ⊗ V2, V3 ⊗ V4)) == P
         @test @constinferred(⊗(V1, V2, V3 ⊗ V4)) == P
         @test @constinferred(⊗(V1, V2 ⊗ V3, V4)) == P
-        @test @constinferred(insertunit(P, 3)) == V1 * V2 * oneunit(V1) * V3 * V4
+        @test V1 * V2 * oneunit(V1) * V3 * V4 ==
+              @constinferred(insertleftunit(P, 3)) ==
+              @constinferred(insertrightunit(P, 2))
         @test @constinferred(removeunit(V1 * V2 * oneunit(V1)' * V3 * V4, 3)) == P
         @test fuse(V1, V2', V3) ≅ V1 ⊗ V2' ⊗ V3
         @test fuse(V1, V2', V3) ≾ V1 ⊗ V2' ⊗ V3
@@ -339,8 +341,10 @@ println("------------------------------------")
         @test @constinferred(*(V1, V2, V3)) == P
         @test @constinferred(⊗(V1, V2, V3)) == P
         @test @constinferred(adjoint(P)) == dual(P) == V3' ⊗ V2' ⊗ V1'
-        @test @constinferred(insertunit(P, 3; conj=true)) == V1 * V2 * oneunit(V1)' * V3
-        @test P == @constinferred(removeunit(insertunit(P, 3), 3))
+        @test V1 * V2 * oneunit(V1)' * V3 ==
+              @constinferred(insertleftunit(P, 3; conj=true)) ==
+              @constinferred(insertrightunit(P, 2; conj=true))
+        @test P == @constinferred(removeunit(insertleftunit(P, 3), 3))
         @test fuse(V1, V2', V3) ≅ V1 ⊗ V2' ⊗ V3
         @test fuse(V1, V2', V3) ≾ V1 ⊗ V2' ⊗ V3 ≾ fuse(V1 ⊗ V2' ⊗ V3)
         @test fuse(V1, V2') ⊗ V3 ≾ V1 ⊗ V2' ⊗ V3
@@ -421,15 +425,21 @@ println("------------------------------------")
         @test W == @constinferred permute(W, ((1, 2), (3, 4, 5)))
         @test permute(W, ((2, 4, 5), (3, 1))) == (V2 ⊗ V4' ⊗ V5' ← V3 ⊗ V1')
         @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred TensorKit.compose(W, W')
-        @test @constinferred(insertunit(W)) == (V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5))
-        @test @constinferred(removeunit(insertunit(W), $(numind(W) + 1))) == W
-        @test @constinferred(insertunit(W; conj=true)) == (V1 ⊗ V2 ←
-                                                           V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5)')
-        @test @constinferred(insertunit(W, 1)) == (oneunit(V1) ⊗ V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5)
-        @test @constinferred(insertunit(W, 3)) == (V1 ⊗ V2 ⊗ oneunit(V1) ← V3 ⊗ V4 ⊗ V5)
-        @test @constinferred(removeunit(insertunit(W, 3), 3)) == W
-        @test @constinferred(insertunit(W, 3; preferdomain=true)) ==
-              (V1 ⊗ V2 ← oneunit(V1) ⊗ V3 ⊗ V4 ⊗ V5)
-        @test @constinferred(removeunit(insertunit(W, 3; preferdomain=true), 3)) == W
+        @test (V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5)) ==
+              @constinferred(insertleftunit(W)) ==
+              @constinferred(insertrightunit(W))
+        @test @constinferred(removeunit(insertleftunit(W), $(numind(W) + 1))) == W
+        @test (V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5)') ==
+              @constinferred(insertleftunit(W; conj=true)) ==
+              @constinferred(insertrightunit(W; conj=true))
+        @test (oneunit(V1) ⊗ V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5) ==
+              @constinferred(insertleftunit(W, 1)) ==
+              @constinferred(insertrightunit(W, 0))
+        @test (V1 ⊗ V2 ⊗ oneunit(V1) ← V3 ⊗ V4 ⊗ V5) ==
+              @constinferred(insertrightunit(W, 2))
+        @test (V1 ⊗ V2 ← oneunit(V1) ⊗ V3 ⊗ V4 ⊗ V5) == @constinferred(insertleftunit(W, 3))
+        @test @constinferred(removeunit(insertleftunit(W, 3), 3)) == W
+        @test @constinferred(insertrightunit(one(V1) ← V1, 0)) == (oneunit(V1) ← V1)
+        @test_throws BoundsError insertleftunit(one(V1) ← V1, 0)
     end
 end

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -422,7 +422,7 @@ println("------------------------------------")
         @test permute(W, ((2, 4, 5), (3, 1))) == (V2 ⊗ V4' ⊗ V5' ← V3 ⊗ V1')
         @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred TensorKit.compose(W, W')
         @test @constinferred(insertunit(W)) == (V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5))
-        @test @constinferred(removeunit(insertunit(W), numind(W) + 1)) == W
+        @test @constinferred(removeunit(insertunit(W), $(numind(W) + 1))) == W
         @test @constinferred(insertunit(W; conj=true)) == (V1 ⊗ V2 ←
                                                            V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5)')
         @test @constinferred(insertunit(W, 1)) == (oneunit(V1) ⊗ V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5)

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -419,5 +419,12 @@ println("------------------------------------")
         @test W == @constinferred permute(W, ((1, 2), (3, 4, 5)))
         @test permute(W, ((2, 4, 5), (3, 1))) == (V2 ⊗ V4' ⊗ V5' ← V3 ⊗ V1')
         @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred TensorKit.compose(W, W')
+        @test @constinferred(insertunit(W)) == (V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5))
+        @test @constinferred(insertunit(W; conj=true)) == (V1 ⊗ V2 ←
+                                                           V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5)')
+        @test @constinferred(insertunit(W, 1)) == (oneunit(V1) ⊗ V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5)
+        @test @constinferred(insertunit(W, 3)) == (V1 ⊗ V2 ⊗ oneunit(V1) ← V3 ⊗ V4 ⊗ V5)
+        @test @constinferred(insertunit(W, 3; preferdomain=true)) ==
+              (V1 ⊗ V2 ← oneunit(V1) ⊗ V3 ⊗ V4 ⊗ V5)
     end
 end

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -279,6 +279,7 @@ println("------------------------------------")
         @test @constinferred(⊗(V1, V2, V3 ⊗ V4)) == P
         @test @constinferred(⊗(V1, V2 ⊗ V3, V4)) == P
         @test @constinferred(insertunit(P, 3)) == V1 * V2 * oneunit(V1) * V3 * V4
+        @test @constinferred(removeunit(V1 * V2 * oneunit(V1)' * V3 * V4, 3)) == P
         @test fuse(V1, V2', V3) ≅ V1 ⊗ V2' ⊗ V3
         @test fuse(V1, V2', V3) ≾ V1 ⊗ V2' ⊗ V3
         @test fuse(V1, V2', V3) ≿ V1 ⊗ V2' ⊗ V3
@@ -339,6 +340,7 @@ println("------------------------------------")
         @test @constinferred(⊗(V1, V2, V3)) == P
         @test @constinferred(adjoint(P)) == dual(P) == V3' ⊗ V2' ⊗ V1'
         @test @constinferred(insertunit(P, 3; conj=true)) == V1 * V2 * oneunit(V1)' * V3
+        @test P == @constinferred(removeunit(insertunit(P, 3), 3))
         @test fuse(V1, V2', V3) ≅ V1 ⊗ V2' ⊗ V3
         @test fuse(V1, V2', V3) ≾ V1 ⊗ V2' ⊗ V3 ≾ fuse(V1 ⊗ V2' ⊗ V3)
         @test fuse(V1, V2') ⊗ V3 ≾ V1 ⊗ V2' ⊗ V3
@@ -420,11 +422,14 @@ println("------------------------------------")
         @test permute(W, ((2, 4, 5), (3, 1))) == (V2 ⊗ V4' ⊗ V5' ← V3 ⊗ V1')
         @test (V1 ⊗ V2 ← V1 ⊗ V2) == @constinferred TensorKit.compose(W, W')
         @test @constinferred(insertunit(W)) == (V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5))
+        @test @constinferred(removeunit(insertunit(W), numind(W) + 1)) == W
         @test @constinferred(insertunit(W; conj=true)) == (V1 ⊗ V2 ←
                                                            V3 ⊗ V4 ⊗ V5 ⊗ oneunit(V5)')
         @test @constinferred(insertunit(W, 1)) == (oneunit(V1) ⊗ V1 ⊗ V2 ← V3 ⊗ V4 ⊗ V5)
         @test @constinferred(insertunit(W, 3)) == (V1 ⊗ V2 ⊗ oneunit(V1) ← V3 ⊗ V4 ⊗ V5)
+        @test @constinferred(removeunit(insertunit(W, 3), 3)) == W
         @test @constinferred(insertunit(W, 3; preferdomain=true)) ==
               (V1 ⊗ V2 ← oneunit(V1) ⊗ V3 ⊗ V4 ⊗ V5)
+        @test @constinferred(removeunit(insertunit(W, 3; preferdomain=true), 3)) == W
     end
 end

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -173,6 +173,32 @@ for V in spacelist
                 @test w * w' == (w * w')^2
             end
         end
+        @timedtestset "Trivial spaces" begin
+            W = V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5
+            for T in (Float32, ComplexF64)
+                t = @constinferred rand(T, W)
+                t2 = @constinferred insertunit(t)
+                @test numind(t2) == numind(t) + 1
+                @test space(t2) == insertunit(space(t))
+                @test scalartype(t2) === T
+                @test t.data === t2.data
+                t3 = @constinferred insertunit(t; copy=true)
+                @test t.data !== t3.data
+                for (c, b) in blocks(t)
+                    @test b == block(t3, c)
+                end
+                t4 = @constinferred insertunit(t, 4; dual=true)
+                @test numin(t4) == numin(t) && numout(t4) == numout(t) + 1
+                for (c, b) in blocks(t)
+                    @test b == block(t4, c)
+                end
+                t5 = @constinferred insertunit(t, 4; dual=true)
+                @test numin(t5) == numin(t) + 1 && numout(t5) == numout(t)
+                for (c, b) in blocks(t)
+                    @test b == block(t5, c)
+                end
+            end
+        end
         if hasfusiontensor(I)
             @timedtestset "Basic linear algebra: test via conversion" begin
                 W = V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -182,13 +182,13 @@ for V in spacelist
                 @test space(t2) == insertunit(space(t))
                 @test scalartype(t2) === T
                 @test t.data === t2.data
-                @test @constinferred(removeunit(t2, numind(t2))) == t
+                @test @constinferred(removeunit(t2, $(numind(t2)))) == t
                 t3 = @constinferred insertunit(t; copy=true)
                 @test t.data !== t3.data
                 for (c, b) in blocks(t)
                     @test b == block(t3, c)
                 end
-                @test @constinferred(removeunit(t3, numind(t3))) == t
+                @test @constinferred(removeunit(t3, $(numind(t3)))) == t
                 t4 = @constinferred insertunit(t, 4; dual=true)
                 @test numin(t4) == numin(t) && numout(t4) == numout(t) + 1
                 for (c, b) in blocks(t)

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -195,7 +195,7 @@ for V in spacelist
                     @test b == block(t4, c)
                 end
                 @test @constinferred(removeunit(t4, 4)) == t
-                t5 = @constinferred insertunit(t, 4; dual=true)
+                t5 = @constinferred insertunit(t, 4; dual=true, preferdomain=true)
                 @test numin(t5) == numin(t) + 1 && numout(t5) == numout(t)
                 for (c, b) in blocks(t)
                     @test b == block(t5, c)

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -177,25 +177,27 @@ for V in spacelist
             W = V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5
             for T in (Float32, ComplexF64)
                 t = @constinferred rand(T, W)
-                t2 = @constinferred insertunit(t)
+                t2 = @constinferred insertleftunit(t)
+                @test t2 == @constinferred insertrightunit(t)
                 @test numind(t2) == numind(t) + 1
-                @test space(t2) == insertunit(space(t))
+                @test space(t2) == insertleftunit(space(t))
                 @test scalartype(t2) === T
                 @test t.data === t2.data
                 @test @constinferred(removeunit(t2, $(numind(t2)))) == t
-                t3 = @constinferred insertunit(t; copy=true)
+                t3 = @constinferred insertleftunit(t; copy=true)
+                @test t3 == @constinferred insertrightunit(t; copy=true)
                 @test t.data !== t3.data
                 for (c, b) in blocks(t)
                     @test b == block(t3, c)
                 end
                 @test @constinferred(removeunit(t3, $(numind(t3)))) == t
-                t4 = @constinferred insertunit(t, 4; dual=true)
+                t4 = @constinferred insertrightunit(t, 3; dual=true)
                 @test numin(t4) == numin(t) && numout(t4) == numout(t) + 1
                 for (c, b) in blocks(t)
                     @test b == block(t4, c)
                 end
                 @test @constinferred(removeunit(t4, 4)) == t
-                t5 = @constinferred insertunit(t, 4; dual=true, preferdomain=true)
+                t5 = @constinferred insertleftunit(t, 4; dual=true)
                 @test numin(t5) == numin(t) + 1 && numout(t5) == numout(t)
                 for (c, b) in blocks(t)
                     @test b == block(t5, c)

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -182,21 +182,25 @@ for V in spacelist
                 @test space(t2) == insertunit(space(t))
                 @test scalartype(t2) === T
                 @test t.data === t2.data
+                @test @constinferred(removeunit(t2, numind(t2))) == t
                 t3 = @constinferred insertunit(t; copy=true)
                 @test t.data !== t3.data
                 for (c, b) in blocks(t)
                     @test b == block(t3, c)
                 end
+                @test @constinferred(removeunit(t3, numind(t3))) == t
                 t4 = @constinferred insertunit(t, 4; dual=true)
                 @test numin(t4) == numin(t) && numout(t4) == numout(t) + 1
                 for (c, b) in blocks(t)
                     @test b == block(t4, c)
                 end
+                @test @constinferred(removeunit(t4, 4)) == t
                 t5 = @constinferred insertunit(t, 4; dual=true)
                 @test numin(t5) == numin(t) + 1 && numout(t5) == numout(t)
                 for (c, b) in blocks(t)
                     @test b == block(t5, c)
                 end
+                @test @constinferred(removeunit(t5, 4)) == t
             end
         end
         if hasfusiontensor(I)


### PR DESCRIPTION
Here I extend the `insertunit` function, which previously only worked for `ProductSpace`, to also include `HomSpace` and `TensorMap` instances. As this is an operation which is quite common in MPSKit, it would be nice to have a centralized implementation for it, which is also more efficient than the current approach which contracts with a trivial vector.

Additionally, I add the `removeunit` function to undo that operation.

I'm not entirely sold on the names and interface I currently have for the function, but I'm struggling to come up with anything better. If you would have more inspiration, I'm all ears.