### PR TITLE
add 🐬  functionality

### DIFF
--- a/src/fusiontrees/manipulations.jl
+++ b/src/fusiontrees/manipulations.jl
@@ -242,6 +242,26 @@ end
 # -> B-move (bendleft, bendright) is simple in standard basis
 # -> A-move (foldleft, foldright) is complicated, needs to be reexpressed in standard form
 
+# flip a duality flag of a fusion tree
+function flip(f₁::FusionTree{I,N₁}, f₂::FusionTree{I,N₂}, i::Int) where {I<:Sector,N₁,N₂}
+    @assert 0 < i ≤ N₁ + N₂
+    if i ≤ N₁
+        a = f₁.uncoupled[i]
+        fs = frobeniusschur(a) * twist(a)
+        factor = f₁.isdual[i] ? fs : one(fs)
+        isdual′ = TupleTools.setindex(f₁.isdual, !f₁.isdual[i], i)
+        f₁′ = FusionTree{I}(f₁.uncoupled, f₁.coupled, isdual′, f₁.innerlines, f₁.vertices)
+        return SingletonDict((f₁′, f₂) => factor)
+    else
+        i -= N₁
+        a = f₂.uncoupled[i]
+        factor = f₂.isdual[i] ? frobeniusschur(a) : twist(a)
+        isdual′ = TupleTools.setindex(f₂.isdual, !f₂.isdual[i], i)
+        f₂′ = FusionTree{I}(f₂.uncoupled, f₂.coupled, isdual′, f₂.innerlines, f₂.vertices)
+        return SingletonDict((f₁, f₂′) => factor)
+    end
+end
+
 # change to N₁ - 1, N₂ + 1
 function bendright(f₁::FusionTree{I,N₁}, f₂::FusionTree{I,N₂}) where {I<:Sector,N₁,N₂}
     # map final splitting vertex (a, b)<-c to fusion vertex a<-(c, dual(b))

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -148,6 +148,22 @@ function select(W::HomSpace{S}, (p₁, p₂)::Index2Tuple{N₁,N₂}) where {S,N
 end
 
 """
+    flip(W::HomSpace, I)
+
+Return a new `HomSpace` object by applying `flip` to each of the spaces in the domain and
+codomain of `W` for which the linear index `i` satisfies `i ∈ I`.
+"""
+function flip(W::HomSpace{S}, I) where {S}
+    cod′ = let cod = codomain(W)
+        ProductSpace{S}(ntuple(i -> i ∈ I ? flip(cod[i]) : cod[i], numout(W)))
+    end
+    dom′ = let dom = domain(W)
+        ProductSpace{S}(ntuple(i -> (i + numout(W)) ∈ I ? flip(dom[i]) : dom[i], numin(W)))
+    end
+    return cod′ ← dom′
+end
+
+"""
     compose(W::HomSpace, V::HomSpace)
 
 Obtain the HomSpace that is obtained from composing the morphisms in `W` and `V`. For this

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -8,13 +8,18 @@ Return a new tensor that is isomorphic to `t` but where the arrows on the indice
 """
 function flip(t::AbstractTensorMap, I)
     P = flip(space(t), I)
-    t2 = similar(t, P)
-    for (c, b) in blocks(t)
-        copy!(t2[c], b)
+    t′ = similar(t, P)
+    for (f₁, f₂) in fusiontrees(t)
+        f₁′, f₂′ = f₁, f₂
+        factor = one(scalartype(t))
+        for i in I
+            (f₁′, f₂′), s = only(flip(f₁′, f₂′, i))
+            factor *= s
+        end
+        scale!(t′[f₁′, f₂′], t[f₁, f₂], factor)
     end
-    return t
+    return t′
 end
-flip(t::TensorMap, I) = TensorMap(t.data, flip(space(t), I))
 
 """
     permute!(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, (p₁, p₂)::Index2Tuple)

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -1,6 +1,22 @@
 # Index manipulations
 #---------------------
 """
+    flip(t::AbstractTensorMap, I) -> t′::AbstractTensorMap
+
+Return a new tensor that is isomorphic to `t` but where the arrows on the indices `i` that satisfy
+`i ∈ I` are flipped, i.e. `space(t′, i) = flip(space(t, i))`.
+"""
+function flip(t::AbstractTensorMap, I)
+    P = flip(space(t), I)
+    t2 = similar(t, P)
+    for (c, b) in blocks(t)
+        copy!(t2[c], b)
+    end
+    return t
+end
+flip(t::TensorMap, I) = TensorMap(t.data, flip(space(t), I))
+
+"""
     permute!(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, (p₁, p₂)::Index2Tuple)
         -> tdst
 

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -326,6 +326,23 @@ for V in spacelist
                 @test HrA12array ≈ convert(Array, HrA12)
             end
         end
+        if BraidingStyle(I) isa Bosonic # TODO: add fermionic tests by including parity tensors
+            @timedtestset "Index flipping: test via contraction" begin
+                t1 = rand(ComplexF64, V1 ⊗ V2 ⊗ V3 ← V4)
+                t2 = rand(ComplexF64, V2' ⊗ V5 ← V4' ⊗ V1)
+                @tensor ta[a, b] := t1[x, y, a, z] * t2[y, b, z, x]
+                @tensor tb[a, b] := flip(t1, 1)[x, y, a, z] * flip(t2, 4)[y, b, z, x]
+                @test ta ≈ tb
+                @tensor tb[a, b] := flip(t1, (2, 4))[x, y, a, z] *
+                                    flip(t2, (1, 3))[y, b, z, x]
+                @test ta ≈ tb
+                @tensor tb[a, b] := flip(t1, (1, 2, 4))[x, y, a, z] *
+                                    flip(t2, (1, 3, 4))[y, b, z, x]
+                @tensor tb[a, b] := flip(t1, (1, 3))[x, y, a, z] *
+                                    flip(t2, (2, 4))[y, b, z, x]
+                @test flip(ta, (1, 2)) ≈ tb
+            end
+        end
         @timedtestset "Multiplication of isometries: test properties" begin
             W2 = V4 ⊗ V5
             W1 = W2 ⊗ (oneunit(V1) ⊕ oneunit(V1))


### PR DESCRIPTION
Flipping tensor indices, for @Adwait-Naravane and @VictorVanthilt . 

Be careful with fermions, as shown in the tests, simply flipping both of a pair of contracted indices does not yield the same contraction when fermions are involved. 