### PR TITLE
Add dedicated `BlockIterator`s

### DIFF
--- a/docs/src/lib/tensors.md
+++ b/docs/src/lib/tensors.md
@@ -82,6 +82,7 @@ spacetype(::Type{<:AbstractTensorMap{<:Any,S}}) where {S}
 sectortype(::Type{TT}) where {TT<:AbstractTensorMap}
 field(::Type{TT}) where {TT<:AbstractTensorMap}
 storagetype
+blocktype
 ```
 
 To obtain information about the indices, you can use:

--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -184,7 +184,7 @@ include("spaces/vectorspaces.jl")
 #-------------------------------------
 # general definitions
 include("tensors/abstracttensor.jl")
-# include("tensors/tensortreeiterator.jl")
+include("tensors/blockiterator.jl")
 include("tensors/tensor.jl")
 include("tensors/adjoint.jl")
 include("tensors/linalg.jl")

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -349,3 +349,18 @@ function fusionblockstructure(W::HomSpace, ::GlobalLRUCache)
     end
     return structure
 end
+
+# Diagonal ranges
+#----------------
+# TODO: is this something we want to cache?
+function diagonalblockstructure(W::HomSpace)
+    structure = SectorDict{sectortype(W),UnitRange{Int}}() # range
+    offset = 0
+    dom = domain(W)[1]
+    for c in blocksectors(W)
+        d = dim(dom, c)
+        structure[c] = offset .+ (1:d)
+        offset += d
+    end
+    return structure
+end

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -355,7 +355,7 @@ end
 # TODO: is this something we want to cache?
 function diagonalblockstructure(W::HomSpace)
     ((numin(W) == numout(W) == 1) && domain(W) == codomain(W)) ||
-        throw(ArgumentError("Input space is not diagonal"))
+        throw(SpaceMismatch("Diagonal only support on V←V with a single space V"))
     structure = SectorDict{sectortype(W),UnitRange{Int}}() # range
     offset = 0
     dom = domain(W)[1]

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -354,6 +354,8 @@ end
 #----------------
 # TODO: is this something we want to cache?
 function diagonalblockstructure(W::HomSpace)
+    ((numin(W) == numout(W) == 1) && domain(W) == codomain(W)) ||
+        throw(ArgumentError("Input space is not diagonal"))
     structure = SectorDict{sectortype(W),UnitRange{Int}}() # range
     offset = 0
     dom = domain(W)[1]

--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -88,12 +88,11 @@ function blocksectors(W::HomSpace)
     N₁ = length(codom)
     N₂ = length(dom)
     I = sectortype(W)
-    if N₁ == 0 || N₂ == 0
-        return (one(I),)
-    elseif N₂ <= N₁
-        return sort!(filter!(c -> hasblock(codom, c), collect(blocksectors(dom))))
+    # TODO: is sort! still necessary now that blocksectors of ProductSpace is sorted?
+    if N₂ <= N₁
+        return sort!(filter!(c -> hasblock(codom, c), blocksectors(dom)))
     else
-        return sort!(filter!(c -> hasblock(dom, c), collect(blocksectors(codom))))
+        return sort!(filter!(c -> hasblock(dom, c), blocksectors(codom)))
     end
 end
 

--- a/src/spaces/productspace.jl
+++ b/src/spaces/productspace.jl
@@ -162,7 +162,7 @@ function blocksectors(P::ProductSpace{S,N}) where {S,N}
             end
         end
     end
-    return bs
+    return sort!(bs)
 end
 
 """

--- a/src/tensors/abstracttensor.jl
+++ b/src/tensors/abstracttensor.jl
@@ -195,6 +195,7 @@ sectortype(t::AbstractTensorMap) = sectortype(typeof(t))
 InnerProductStyle(t::AbstractTensorMap) = InnerProductStyle(typeof(t))
 field(t::AbstractTensorMap) = field(typeof(t))
 storagetype(t::AbstractTensorMap) = storagetype(typeof(t))
+blocktype(t::AbstractTensorMap) = blocktype(typeof(t))
 similarstoragetype(t::AbstractTensorMap, T=scalartype(t)) = similarstoragetype(typeof(t), T)
 
 numout(t::AbstractTensorMap) = numout(typeof(t))
@@ -309,6 +310,15 @@ Return the matrix block of a tensor corresponding to a coupled sector `c`.
 
 See also [`blocks`](@ref), [`blocksectors`](@ref), [`blockdim`](@ref) and [`hasblock`](@ref).
 """ block
+
+@doc """
+    blocktype(t)
+
+Return the type of the matrix blocks of a tensor.
+""" blocktype
+function blocktype(::Type{T}) where {T<:AbstractTensorMap}
+    return Core.Compiler.return_type(block, Tuple{T,sectortype(T)})
+end
 
 # Derived indexing behavior for tensors with trivial symmetry
 #-------------------------------------------------------------

--- a/src/tensors/adjoint.jl
+++ b/src/tensors/adjoint.jl
@@ -25,11 +25,21 @@ storagetype(::Type{AdjointTensorMap{T,S,N₁,N₂,TT}}) where {T,S,N₁,N₂,TT}
 #----------------------
 block(t::AdjointTensorMap, s::Sector) = block(parent(t), s)'
 
-function blocks(t::AdjointTensorMap)
-    iter = Base.Iterators.map(blocks(parent(t))) do (c, b)
-        return c => b'
-    end
-    return iter
+blocks(t::AdjointTensorMap) = BlockIterator(t, blocks(parent(t)))
+
+function blocktype(::Type{TT}) where {T,TT<:AdjointTensorMap{T}}
+    return Base.promote_op(adjoint, blocktype(T))
+end
+
+function Base.iterate(iter::BlockIterator{<:AdjointTensorMap}, state...)
+    next = iterate(iter.structure, state...)
+    isnothing(next) && return next
+    (c, b), newstate = next
+    return c => adjoint(b), newstate
+end
+
+function Base.getindex(iter::BlockIterator{<:AdjointTensorMap}, c::Sector)
+    return adjoint(Base.getindex(iter.structure, c))
 end
 
 function Base.getindex(t::AdjointTensorMap{T,S,N₁,N₂},

--- a/src/tensors/adjoint.jl
+++ b/src/tensors/adjoint.jl
@@ -27,8 +27,8 @@ block(t::AdjointTensorMap, s::Sector) = block(parent(t), s)'
 
 blocks(t::AdjointTensorMap) = BlockIterator(t, blocks(parent(t)))
 
-function blocktype(::Type{TT}) where {T,TT<:AdjointTensorMap{T}}
-    return Base.promote_op(adjoint, blocktype(T))
+function blocktype(::Type{AdjointTensorMap{T,S,N₁,N₂,TT}}) where {T,S,N₁,N₂,TT}
+    return Base.promote_op(adjoint, blocktype(TT))
 end
 
 function Base.iterate(iter::BlockIterator{<:AdjointTensorMap}, state...)

--- a/src/tensors/blockiterator.jl
+++ b/src/tensors/blockiterator.jl
@@ -1,0 +1,15 @@
+"""
+    struct BlockIterator{T<:AbstractTensorMap,S}
+
+Iterator over the blocks of type `T`, possibly holding some pre-computed data of type `S`
+"""
+struct BlockIterator{T<:AbstractTensorMap,S}
+    t::T
+    structure::S
+end
+
+Base.IteratorSize(::BlockIterator) = Base.HasLength()
+Base.IteratorEltype(::BlockIterator) = Base.HasEltype()
+Base.eltype(::Type{<:BlockIterator{T}}) where {T} = blocktype(T)
+Base.length(iter::BlockIterator) = length(iter.structure)
+Base.isdone(iter::BlockIterator, state...) = Base.isdone(iter.structure, state...)

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -111,7 +111,9 @@ function block(d::DiagonalTensorMap, s::Sector)
 end
 
 blocks(t::DiagonalTensorMap) = BlockIterator(t, diagonalblockstructure(space(t)))
-blocktype(::Type{TT}) where {TT<:DiagonalTensorMap} = Diagonal{eltype(TT),storagetype(TT)}
+function blocktype(::Type{DiagonalTensorMap{T,S,A}}) where {T,S,A}
+    return Diagonal{T,SubArray{T,1,A,Tuple{UnitRange{Int}},true}}
+end
 
 function Base.iterate(iter::BlockIterator{<:DiagonalTensorMap}, state...)
     next = iterate(iter.structure, state...)

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -14,6 +14,15 @@ diagspacelist = ((ℂ^4)', ℂ[Z2Irrep](0 => 2, 1 => 3),
             @test space(t) == (V ← V)
             @test space(t') == (V ← V)
             @test dim(t) == dim(space(t))
+            # blocks
+            bs = @constinferred blocks(t)
+            (c, b1), state = @constinferred Nothing iterate(bs)
+            @test c == first(blocksectors(V ← V))
+            next = @constinferred Nothing iterate(bs, state)
+            b2 = @constinferred block(t, first(blocksectors(t)))
+            @test b1 == b2
+            @test eltype(bs) === typeof(b1) === TensorKit.blocktype(t)
+            # basic linear algebra
             @test isa(@constinferred(norm(t)), real(T))
             @test norm(t)^2 ≈ dot(t, t)
             α = rand(T)

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -91,6 +91,9 @@ for V in spacelist
                 @test space(t) == (W ← one(W))
                 @test domain(t) == one(W)
                 @test typeof(t) == TensorMap{T,spacetype(t),5,0,Vector{T}}
+                bs = @inferred blocks(t)
+                b = @inferred block(t, first(blocksectors(t)))
+                @test eltype(bs) === typeof(b) === TensorKit.blocktype(t)
             end
         end
         @timedtestset "Tensor Dict conversion" begin

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -91,9 +91,14 @@ for V in spacelist
                 @test space(t) == (W ← one(W))
                 @test domain(t) == one(W)
                 @test typeof(t) == TensorMap{T,spacetype(t),5,0,Vector{T}}
-                bs = @inferred blocks(t)
-                b = @inferred block(t, first(blocksectors(t)))
-                @test eltype(bs) === typeof(b) === TensorKit.blocktype(t)
+                # blocks
+                bs = @constinferred blocks(t)
+                (c, b1), state = @constinferred Nothing iterate(bs)
+                @test c == first(blocksectors(W))
+                next = @constinferred Nothing iterate(bs, state)
+                b2 = @constinferred block(t, first(blocksectors(t)))
+                @test b1 == b2
+                @test eltype(bs) === typeof(b1) === TensorKit.blocktype(t)
             end
         end
         @timedtestset "Tensor Dict conversion" begin
@@ -146,6 +151,15 @@ for V in spacelist
                 @test dim(t) == dim(space(t))
                 @test codomain(t) == codomain(W)
                 @test domain(t) == domain(W)
+                # blocks for adjoint
+                bs = @constinferred blocks(t')
+                (c, b1), state = @constinferred Nothing iterate(bs)
+                @test c == first(blocksectors(W'))
+                next = @constinferred Nothing iterate(bs, state)
+                b2 = @constinferred block(t', first(blocksectors(t')))
+                @test b1 == b2
+                @test eltype(bs) === typeof(b1) === TensorKit.blocktype(t')
+                # linear algebra
                 @test isa(@constinferred(norm(t)), real(T))
                 @test norm(t)^2 ≈ dot(t, t)
                 α = rand(T)


### PR DESCRIPTION
This PR adds some dedicated iterators for going through the blocks of a single tensor.
This replaces the previous default implementation in terms of `Iterators.map`, in order to have more type stability (well-defined `eltype` and `length`), and the option to index into the iterators.
This should otherwise not change any external functionality (and in particular, it re-enables the syntax `blocks(t)[c]`, which worked before v0.13) so I think it could be considered non-breaking.