### PR TITLE
DiagonalTensorMap constructor rrule 

### DIFF
--- a/ext/TensorKitChainRulesCoreExt/constructors.jl
+++ b/ext/TensorKitChainRulesCoreExt/constructors.jl
@@ -21,7 +21,7 @@ function ChainRulesCore.rrule(::Type{TensorMap{T}}, data::DenseVector,
     function TensorMap_pullback(Δt_)
         Δt = copy(unthunk(Δt_))
         for (c, b) in blocks(Δt)
-            scale!(b, TensorKit.sqrtdim(c))
+            scale!(b, TensorKit.invsqrtdim(c))
         end
         ∂data = P(Δt.data)
         return NoTangent(), ∂data, NoTangent()
@@ -37,7 +37,7 @@ function ChainRulesCore.rrule(::Type{<:DiagonalTensorMap}, data::DenseVector, ar
         # unclear if we're allowed to modify/take ownership of the input
         Δt = copy(unthunk(Δt_))
         for (c, b) in blocks(Δt)
-            scale!(b, TensorKit.sqrtdim(c))
+            scale!(b, TensorKit.invsqrtdim(c))
         end
         ∂data = P(Δt.data)
         return NoTangent(), ∂data, NoTangent()
@@ -51,7 +51,7 @@ function ChainRulesCore.rrule(::typeof(Base.getproperty), t::TensorMap, prop::Sy
             # unclear if we're allowed to modify/take ownership of the input
             t′ = typeof(t)(copy(unthunk(Δdata)), t.space)
             for (c, b) in blocks(t′)
-                scale!(b, TensorKit.invsqrtdim(c))
+                scale!(b, TensorKit.sqrtdim(c))
             end
             return NoTangent(), t′, NoTangent()
         end
@@ -70,7 +70,7 @@ function ChainRulesCore.rrule(::typeof(Base.getproperty), t::DiagonalTensorMap,
             # unclear if we're allowed to modify/take ownership of the input
             t′ = typeof(t)(copy(unthunk(Δdata)), t.domain)
             for (c, b) in blocks(t′)
-                scale!(b, TensorKit.invsqrtdim(c))
+                scale!(b, TensorKit.sqrtdim(c))
             end
             return NoTangent(), t′, NoTangent()
         end

--- a/ext/TensorKitChainRulesCoreExt/constructors.jl
+++ b/ext/TensorKitChainRulesCoreExt/constructors.jl
@@ -12,9 +12,10 @@ function ChainRulesCore.rrule(::Type{<:TensorMap}, d::DenseArray, args...; kwarg
     return TensorMap(d, args...; kwargs...), TensorMap_pullback
 end
 
-function ChainRulesCore.rrule(::Type{<:DiagonalTensorMap}, d::DenseVector, args...; kwargs...)
-    D=TensorMap(d, args...; kwargs...)
-    project_D=ProjectTo(D)
+function ChainRulesCore.rrule(::Type{<:DiagonalTensorMap}, d::DenseVector, args...;
+                              kwargs...)
+    D = DiagonalTensorMap(d, args...; kwargs...)
+    project_D = ProjectTo(D)
     function DiagonalTensorMap_pullback(Δt)
         ∂d = project_D(unthunk(Δt)).data
         return NoTangent(), ∂d, ntuple(_ -> NoTangent(), length(args))...

--- a/ext/TensorKitChainRulesCoreExt/linalg.jl
+++ b/ext/TensorKitChainRulesCoreExt/linalg.jl
@@ -106,3 +106,21 @@ function ChainRulesCore.rrule(::typeof(imag), a::AbstractTensorMap)
     end
     return a_imag, imag_pullback
 end
+
+# define rrules for matrix functions for DiagonalTensorMap, since they access data directly.
+for f in
+    (:exp, :cos, :sin, :tan, :cot, :cosh, :sinh, :tanh, :coth, :atan, :acot, :asinh, :sqrt,
+     :log, :asin, :acos, :acosh, :atanh, :acoth)
+    f_pullback = Symbol(f, :_pullback)
+    @eval function ChainRulesCore.rrule(cfg::RuleConfig{>:HasReverseMode}, ::typeof($f),
+                                        t::DiagonalTensorMap)
+        P = ProjectTo(t) # unsure if this is necessary, should already be in pullback
+        d, pullback = rrule_via_ad(cfg, broadcast, $f, t.data)
+        function $f_pullback(Δd_)
+            Δd = P(unthunk(Δd_))
+            _, _, ∂data = pullback(Δd.data)
+            return NoTangent(), DiagonalTensorMap(∂data, t.domain)
+        end
+        return DiagonalTensorMap(d, t.domain), $f_pullback
+    end
+end

--- a/ext/TensorKitChainRulesCoreExt/utility.jl
+++ b/ext/TensorKitChainRulesCoreExt/utility.jl
@@ -30,9 +30,11 @@ function (::ProjectTo{T1})(x::T2) where {S,N1,N2,T1<:AbstractTensorMap{<:Any,S,N
     return y
 end
 
-function (::ProjectTo{T1})(x::T2) where {T1<:DiagonalTensorMap,T2<:AbstractTensorMap}
-    T1 === T2 && return x
-    y = DiagonalTensorMap{scalartype(T1),spacetype(T1),storagetype(T1)}(undef, space(x, 1))
+function (::ProjectTo{DiagonalTensorMap{T,S,A}})(x::AbstractTensorMap) where {T,S,A}
+    x isa DiagonalTensorMap{T,S,A} && return x
+    V = space(x, 1)
+    space(x) == (V ← V) || throw(SpaceMismatch())
+    y = DiagonalTensorMap{T,S,A}(undef, V)
     for (c, b) in blocks(y)
         p = ProjectTo(b)
         b .= p(block(x, c))

--- a/ext/TensorKitChainRulesCoreExt/utility.jl
+++ b/ext/TensorKitChainRulesCoreExt/utility.jl
@@ -29,3 +29,15 @@ function (::ProjectTo{T1})(x::T2) where {S,N1,N2,T1<:AbstractTensorMap{<:Any,S,N
     end
     return y
 end
+
+function (::ProjectTo{T1})(x::T2) where {S,NumType,StorType,
+                                         T1<:DiagonalTensorMap{NumType,S,StorType},
+                                         T2<:AbstractTensorMap{<:Any,S,1,1}}
+    T1 === T2 && return x
+    y = DiagonalTensorMap{NumType,S,StorType}(undef, space(x, 1))
+    for (c, b) in blocks(y)
+        p = ProjectTo(b)
+        b .= p(block(x, c))
+    end
+    return y
+end

--- a/ext/TensorKitChainRulesCoreExt/utility.jl
+++ b/ext/TensorKitChainRulesCoreExt/utility.jl
@@ -30,11 +30,9 @@ function (::ProjectTo{T1})(x::T2) where {S,N1,N2,T1<:AbstractTensorMap{<:Any,S,N
     return y
 end
 
-function (::ProjectTo{T1})(x::T2) where {S,NumType,StorType,
-                                         T1<:DiagonalTensorMap{NumType,S,StorType},
-                                         T2<:AbstractTensorMap{<:Any,S,1,1}}
+function (::ProjectTo{T1})(x::T2) where {T1<:DiagonalTensorMap,T2<:AbstractTensorMap}
     T1 === T2 && return x
-    y = DiagonalTensorMap{NumType,S,StorType}(undef, space(x, 1))
+    y = DiagonalTensorMap{scalartype(T1),spacetype(T1),storagetype(T1)}(undef, space(x, 1))
     for (c, b) in blocks(y)
         p = ProjectTo(b)
         b .= p(block(x, c))

--- a/ext/TensorKitFiniteDifferencesExt.jl
+++ b/ext/TensorKitFiniteDifferencesExt.jl
@@ -23,6 +23,14 @@ function FiniteDifferences.to_vec(t::AbstractTensorMap)
 end
 FiniteDifferences.to_vec(t::TensorKit.AdjointTensorMap) = to_vec(copy(t))
 
+function FiniteDifferences.to_vec(t::DiagonalTensorMap)
+    x_vec, back = to_vec(TensorMap(t))
+    function DiagonalTensorMap_from_vec(x_vec)
+        return DiagonalTensorMap(back(x_vec))
+    end
+    return x_vec, DiagonalTensorMap_from_vec
+end
+
 end
 
 # TODO: Investigate why the approach below doesn't work

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -87,20 +87,6 @@ end
 TensorMap(d::DiagonalTensorMap) = copy!(similar(d), d)
 Base.convert(::Type{TensorMap}, d::DiagonalTensorMap) = TensorMap(d)
 
-# similar to Diagonal: simply take diagonal
-function DiagonalTensorMap(t::AbstractTensorMap)
-    numin(t) == numout(t) == 1 && domain(t) == codomain(t) || throw(SpaceMismatch())
-    d = DiagonalTensorMap{scalartype(t)}(undef, space(t, 1))
-    for (c, b) in blocks(t)
-        copy!(block(d, c), Diagonal(b))
-    end
-    return d
-end
-
-function Base.convert(::Type{DiagonalTensorMap{T,S,A}},
-                      d::DiagonalTensorMap{T,S,A}) where {T,S,A}
-    return d
-end
 function Base.convert(D::Type{<:DiagonalTensorMap}, d::DiagonalTensorMap)
     return (d isa D) ? d : DiagonalTensorMap(convert(storagetype(D), d.data), d.domain)
 end

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -73,6 +73,16 @@ end
 TensorMap(d::DiagonalTensorMap) = copy!(similar(d), d)
 Base.convert(::Type{TensorMap}, d::DiagonalTensorMap) = TensorMap(d)
 
+# similar to Diagonal: simply take diagonal
+function DiagonalTensorMap(t::AbstractTensorMap)
+    numin(t) == numout(t) == 1 && domain(t) == codomain(t) || throw(SpaceMismatch())
+    d = DiagonalTensorMap{scalartype(t)}(undef, space(t, 1))
+    for (c, b) in blocks(t)
+        copy!(block(d, c), Diagonal(b))
+    end
+    return d
+end
+
 function Base.convert(::Type{DiagonalTensorMap{T,S,A}},
                       d::DiagonalTensorMap{T,S,A}) where {T,S,A}
     return d

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -235,15 +235,9 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
             t1 = randn(T, V[1] ← V[1])
             t2 = randn(T, V[2] ← V[2])
             d = DiagonalTensorMap{T}(undef, V[1])
-            randn!(d.data)
-            if T <: Real
-                d.data .= abs.(d.data)
-            end
+            (T <: Real && f === sqrt) ? randexp!(d.data) : randn!(d.data)
             d2 = DiagonalTensorMap{T}(undef, V[1])
-            randn!(d2.data)
-            if T <: Real
-                d2.data .= abs.(d2.data)
-            end
+            (T <: Real && f === sqrt) ? randexp!(d2.data) : randn!(d2.data)
             test_rrule(f, t1; rrule_f=Zygote.rrule_via_ad, check_inferred)
             test_rrule(f, t2; rrule_f=Zygote.rrule_via_ad, check_inferred)
             test_rrule(f, d; check_inferred, output_tangent=d2)

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -148,16 +148,33 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
     end
 
     @timedtestset "Basic utility (DiagonalTensor)" begin
-        for NumType in [Float64, ComplexF64]
-            for v in V
-                T1 = DiagonalTensorMap(randn(NumType, dim(v)), v)
-                T2 = TensorMap(T1)
+        for v in V
+            D1 = DiagonalTensorMap(randn(dim(v)), v)
+            D2 = DiagonalTensorMap(randn(dim(v)), v)
+            D = D1 + im * D2
+            T1 = TensorMap(D1)
+            T2 = TensorMap(D2)
+            T = T1 + im * T2
 
-                P1 = ProjectTo(T1)
-                @test P1(T2) == T1
+            # real -> real
+            P1 = ProjectTo(D1)
+            @test P1(D1) == D1
+            @test P1(T1) == D1
 
-                test_rrule(DiagonalTensorMap, T1.data, T1.domain)
-            end
+            # complex -> complex
+            P2 = ProjectTo(D)
+            @test P2(D) == D
+            @test P2(T) == D
+
+            # real -> complex 
+            @test P2(D1) == D1 + 0 * im * D1
+            @test P2(T1) == D1 + 0 * im * D1
+
+            # complex -> real
+            @test P1(D) == D1
+            @test P1(T) == D1
+
+            test_rrule(DiagonalTensorMap, D1.data, D1.domain)
         end
     end
 

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -156,7 +156,7 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
                 P1 = ProjectTo(T1)
                 @test P1(T2) == T1
 
-                test_rrule(DiagonalTensorMap, T1.data, T1.domain)
+                @test test_rrule(DiagonalTensorMap, T1.data, T1.domain)
             end
         end
     end

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -153,9 +153,10 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
         if symmetricbraiding
             test_rrule(TensorKit.permutedcopy_oftype, T1, ComplexF64, ((3, 1), (2, 4)))
 
-        test_rrule(convert, Array, T1)
-        test_rrule(TensorMap, convert(Array, T1), codomain(T1), domain(T1);
-                   fkwargs=(; tol=Inf))
+            test_rrule(convert, Array, T1)
+            test_rrule(TensorMap, convert(Array, T1), codomain(T1), domain(T1);
+                       fkwargs=(; tol=Inf))
+        end
 
         test_rrule(Base.getproperty, T1, :data)
         test_rrule(TensorMap{scalartype(T1)}, T1.data, T1.space)

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -156,7 +156,7 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
                 P1 = ProjectTo(T1)
                 @test P1(T2) == T1
 
-                @test test_rrule(DiagonalTensorMap, T1.data, T1.domain)
+                test_rrule(DiagonalTensorMap, T1.data, T1.domain)
             end
         end
     end

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -176,8 +176,8 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
             @test P1(D) == D1
             @test P1(T) == D1
 
-            test_rrule(DiagonalTensorMap, D1.data, D1.domain)
-            test_rrule(DiagonalTensorMap, D.data, D.domain)
+            test_rrule(DiagonalTensorMap, D1.data, D1.domain) # test fails when dimension dim of the representation is not 1.  
+            test_rrule(DiagonalTensorMap, D.data, D.domain) # the finite diff result is larger than the exact result exactly in dim times. It should be something with how diagonal tensor transforms into a vector. 
         end
     end
 

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -15,6 +15,9 @@ end
 function ChainRulesTestUtils.rand_tangent(rng::AbstractRNG, x::AbstractTensorMap)
     return randn!(similar(x))
 end
+function ChainRulesTestUtils.rand_tangent(rng::AbstractRNG, x::DiagonalTensorMap)
+    return DiagonalTensorMap(randn(eltype(x), dim(x.domain)), x.domain)
+end
 ChainRulesTestUtils.rand_tangent(::AbstractRNG, ::VectorSpace) = NoTangent()
 function ChainRulesTestUtils.test_approx(actual::AbstractTensorMap,
                                          expected::AbstractTensorMap, msg=""; kwargs...)
@@ -142,6 +145,20 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
         test_rrule(convert, Array, T1)
         test_rrule(TensorMap, convert(Array, T1), codomain(T1), domain(T1);
                    fkwargs=(; tol=Inf))
+    end
+
+    @timedtestset "Basic utility (DiagonalTensor)" begin
+        for NumType in [Float64, ComplexF64]
+            for v in V
+                T1 = DiagonalTensorMap(randn(NumType, dim(v)), v)
+                T2 = TensorMap(T1)
+
+                P1 = ProjectTo(T1)
+                @test P1(T2) == T1
+
+                test_rrule(DiagonalTensorMap, T1.data, T1.domain)
+            end
+        end
     end
 
     @timedtestset "Basic Linear Algebra with scalartype $T" for T in (Float64, ComplexF64)

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -16,7 +16,8 @@ function ChainRulesTestUtils.rand_tangent(rng::AbstractRNG, x::AbstractTensorMap
     return randn!(similar(x))
 end
 function ChainRulesTestUtils.rand_tangent(rng::AbstractRNG, x::DiagonalTensorMap)
-    return DiagonalTensorMap(randn(eltype(x), dim(x.domain)), x.domain)
+    S = x.domain
+    return DiagonalTensorMap(randn(eltype(x), sum(values(S.dims))), S)
 end
 ChainRulesTestUtils.rand_tangent(::AbstractRNG, ::VectorSpace) = NoTangent()
 function ChainRulesTestUtils.test_approx(actual::AbstractTensorMap,

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -177,8 +177,12 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
             @test P1(D) == D1
             @test P1(T) == D1
 
-            test_rrule(DiagonalTensorMap, D1.data, D1.domain) # test fails when dimension dim of the representation is not 1.  
-            test_rrule(DiagonalTensorMap, D.data, D.domain) # the finite diff result is larger than the exact result exactly in dim times. It should be something with how diagonal tensor transforms into a vector. 
+            # These tests fail because here the data vector are the actual parameters,
+            # not a vectorized version of the tensor. (off by a quantum dimension factor)
+            if FusionStyle(sectortype(D)) == UniqueFusion()
+                test_rrule(DiagonalTensorMap, D1.data, D1.domain)
+                test_rrule(DiagonalTensorMap, D.data, D.domain)
+            end
         end
     end
 

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -147,6 +147,11 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
         test_rrule(convert, Array, T1)
         test_rrule(TensorMap, convert(Array, T1), codomain(T1), domain(T1);
                    fkwargs=(; tol=Inf))
+
+        test_rrule(Base.getproperty, T1, :data)
+        test_rrule(TensorMap{scalartype(T1)}, T1.data, T1.space)
+        test_rrule(Base.getproperty, T2, :data)
+        test_rrule(TensorMap{scalartype(T2)}, T2.data, T2.space)
     end
 
     @timedtestset "Basic utility (DiagonalTensor)" begin
@@ -177,12 +182,10 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
             @test P1(D) == D1
             @test P1(T) == D1
 
-            # These tests fail because here the data vector are the actual parameters,
-            # not a vectorized version of the tensor. (off by a quantum dimension factor)
-            if FusionStyle(sectortype(D)) == UniqueFusion()
-                test_rrule(DiagonalTensorMap, D1.data, D1.domain)
-                test_rrule(DiagonalTensorMap, D.data, D.domain)
-            end
+            test_rrule(DiagonalTensorMap, D1.data, D1.domain)
+            test_rrule(DiagonalTensorMap, D.data, D.domain)
+            test_rrule(Base.getproperty, D, :data)
+            test_rrule(Base.getproperty, D1, :data)
         end
     end
 

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -175,6 +175,7 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
             @test P1(T) == D1
 
             test_rrule(DiagonalTensorMap, D1.data, D1.domain)
+            test_rrule(DiagonalTensorMap, D.data, D.domain)
         end
     end
 

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -16,8 +16,8 @@ function ChainRulesTestUtils.rand_tangent(rng::AbstractRNG, x::AbstractTensorMap
     return randn!(similar(x))
 end
 function ChainRulesTestUtils.rand_tangent(rng::AbstractRNG, x::DiagonalTensorMap)
-    S = x.domain
-    return DiagonalTensorMap(randn(eltype(x), sum(values(S.dims))), S)
+    V = x.domain
+    return DiagonalTensorMap(randn(eltype(x), reduceddim(V)), V)
 end
 ChainRulesTestUtils.rand_tangent(::AbstractRNG, ::VectorSpace) = NoTangent()
 function ChainRulesTestUtils.test_approx(actual::AbstractTensorMap,
@@ -150,9 +150,9 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
 
     @timedtestset "Basic utility (DiagonalTensor)" begin
         for v in V
-            comp_num = sum(values(v.dims))
-            D1 = DiagonalTensorMap(randn(comp_num), v)
-            D2 = DiagonalTensorMap(randn(comp_num), v)
+            rdim = reduceddim(v)
+            D1 = DiagonalTensorMap(randn(rdim), v)
+            D2 = DiagonalTensorMap(randn(rdim), v)
             D = D1 + im * D2
             T1 = TensorMap(D1)
             T2 = TensorMap(D2)

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -149,8 +149,9 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
 
     @timedtestset "Basic utility (DiagonalTensor)" begin
         for v in V
-            D1 = DiagonalTensorMap(randn(dim(v)), v)
-            D2 = DiagonalTensorMap(randn(dim(v)), v)
+            comp_num = sum(values(v.dims))
+            D1 = DiagonalTensorMap(randn(comp_num), v)
+            D2 = DiagonalTensorMap(randn(comp_num), v)
             D = D1 + im * D2
             T1 = TensorMap(D1)
             T2 = TensorMap(D2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,9 +60,13 @@ include("spaces.jl")
 include("tensors.jl")
 include("diagonal.jl")
 include("planar.jl")
-if !(Sys.isapple()) # TODO: remove once we know why this is so slow on macOS
-    include("ad.jl")
+# TODO: remove once we know AD is slow on macOS CI
+test_ad = try
+    !(Sys.isapple() && ENV["CI"] == true)
+catch
+    true
 end
+test_ad && include("ad.jl")
 include("bugfixes.jl")
 Tf = time()
 printstyled("Finished all tests in ",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,7 +62,7 @@ include("diagonal.jl")
 include("planar.jl")
 # TODO: remove once we know AD is slow on macOS CI
 test_ad = try
-    !(Sys.isapple() && ENV["CI"] == true)
+    !(Sys.isapple() && ENV["CI"] == "true")
 catch
     true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,11 +55,11 @@ sectorlist = (Z2Irrep, Z3Irrep, Z4Irrep, Z3Irrep ⊠ Z4Irrep,
               Z2Irrep ⊠ FibonacciAnyon ⊠ FibonacciAnyon)
 
 Ti = time()
-# include("fusiontrees.jl")
-# include("spaces.jl")
-# include("tensors.jl")
-# include("diagonal.jl")
-# include("planar.jl")
+include("fusiontrees.jl")
+include("spaces.jl")
+include("tensors.jl")
+include("diagonal.jl")
+include("planar.jl")
 # TODO: remove once we know AD is slow on macOS CI
 if !(Sys.isapple() && get(ENV, "CI", "false") == "true")
     include("ad.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,12 +61,9 @@ include("tensors.jl")
 include("diagonal.jl")
 include("planar.jl")
 # TODO: remove once we know AD is slow on macOS CI
-test_ad = try
-    !(Sys.isapple() && ENV["CI"] == "true")
-catch
-    true
+if !(Sys.isapple() && get(ENV, "CI", "false") == "true")
+    include("ad.jl")
 end
-test_ad && include("ad.jl")
 include("bugfixes.jl")
 Tf = time()
 printstyled("Finished all tests in ",


### PR DESCRIPTION
This PR adds `rrule` for the `DiagonalTensorMap` constructor and defines `ProjectTo` for `DiagonalTensorMap`. 