### PR TITLE
Fix rrules of TensorOperations with `DiagonalTensorMap`

### DIFF
--- a/ext/TensorKitChainRulesCoreExt/TensorKitChainRulesCoreExt.jl
+++ b/ext/TensorKitChainRulesCoreExt/TensorKitChainRulesCoreExt.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 using TupleTools
 
 import TensorOperations as TO
-using TensorOperations: promote_contract
+using TensorOperations: promote_contract, tensoralloc_add, tensoralloc_contract
 using VectorInterface: promote_scale, promote_add
 
 include("utility.jl")

--- a/ext/TensorKitChainRulesCoreExt/tensoroperations.jl
+++ b/ext/TensorKitChainRulesCoreExt/tensoroperations.jl
@@ -61,8 +61,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
         pΔC = _repartition(ipAB, TO.numout(pA))
 
         dC = @thunk projectC(scale(ΔC, conj(β)))
-        dA = @thunk let
-            ipA = _repartition(invperm(linearize(pA)), A)
+        dA = @thunk let ipA = _repartition(invperm(linearize(pA)), A)
             conjΔC = conjA
             conjB′ = conjA ? conjB : !conjB
             TA = promote_contract(scalartype(ΔC), scalartype(B), scalartype(α))
@@ -78,8 +77,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
                                   conjA ? α : conj(α), Zero(), ba...)
             return projectA(_dA)
         end
-        dB = @thunk let
-            ipB = _repartition(invperm(linearize(pB)), B)
+        dB = @thunk let ipB = _repartition(invperm(linearize(pB)), B)
             conjΔC = conjB
             conjA′ = conjB ? conjA : !conjA
             TB = promote_contract(scalartype(ΔC), scalartype(A), scalartype(α))
@@ -125,9 +123,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensortrace!),
     function pullback(ΔC′)
         ΔC = unthunk(ΔC′)
         dC = @thunk projectC(scale(ΔC, conj(β)))
-        dA = @thunk let
-            ip = invperm((linearize(p)..., q[1]..., q[2]...))
-            pdA = _repartition(ip, A)
+        dA = @thunk let ip = invperm((linearize(p)..., q[1]..., q[2]...)), pdA = _repartition(ip, A)
             E = one!(TO.tensoralloc_add(scalartype(A), A, q, conjA))
             twist!(E, filter(x -> !isdual(space(E, x)), codomainind(E)))
             pE = ((), trivtuple(TO.numind(q)))

--- a/ext/TensorKitChainRulesCoreExt/tensoroperations.jl
+++ b/ext/TensorKitChainRulesCoreExt/tensoroperations.jl
@@ -61,7 +61,8 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
         pΔC = _repartition(ipAB, TO.numout(pA))
 
         dC = @thunk projectC(scale(ΔC, conj(β)))
-        dA = @thunk let ipA = _repartition(invperm(linearize(pA)), A)
+        dA = @thunk let
+            ipA = _repartition(invperm(linearize(pA)), A)
             conjΔC = conjA
             conjB′ = conjA ? conjB : !conjB
             TA = promote_contract(scalartype(ΔC), scalartype(B), scalartype(α))
@@ -77,7 +78,8 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
                                   conjA ? α : conj(α), Zero(), ba...)
             return projectA(_dA)
         end
-        dB = @thunk let ipB = _repartition(invperm(linearize(pB)), B)
+        dB = @thunk let
+            ipB = _repartition(invperm(linearize(pB)), B)
             conjΔC = conjB
             conjA′ = conjB ? conjA : !conjA
             TB = promote_contract(scalartype(ΔC), scalartype(A), scalartype(α))
@@ -123,7 +125,9 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensortrace!),
     function pullback(ΔC′)
         ΔC = unthunk(ΔC′)
         dC = @thunk projectC(scale(ΔC, conj(β)))
-        dA = @thunk let ip = invperm((linearize(p)..., q[1]..., q[2]...)), pdA = _repartition(ip, A)
+        dA = @thunk let
+            ip = invperm((linearize(p)..., q[1]..., q[2]...))
+            pdA = _repartition(ip, A)
             E = one!(TO.tensoralloc_add(scalartype(A), A, q, conjA))
             twist!(E, filter(x -> !isdual(space(E, x)), codomainind(E)))
             pE = ((), trivtuple(TO.numind(q)))

--- a/ext/TensorKitChainRulesCoreExt/tensoroperations.jl
+++ b/ext/TensorKitChainRulesCoreExt/tensoroperations.jl
@@ -14,7 +14,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
         dC = @thunk projectC(scale(ΔC, conj(β)))
         dA = @thunk let
             ipA = invperm(linearize(pA))
-            _dA = zerovector(A, promote_add(ΔC, α))
+            _dA = similar(A, promote_add(ΔC, α))
             _dA = tensoradd!(_dA, ΔC, (ipA, ()), conjA, conjA ? α : conj(α), Zero(), ba...)
             return projectA(_dA)
         end
@@ -63,8 +63,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
             ipA = (invperm(linearize(pA)), ())
             conjΔC = conjA
             conjB′ = conjA ? conjB : !conjB
-            _dA = zerovector(A,
-                             promote_contract(scalartype(ΔC), scalartype(B), scalartype(α)))
+            _dA = similar(A, promote_contract(scalartype(ΔC), scalartype(B), scalartype(α)))
             tB = twist(B,
                        TupleTools.vcat(filter(x -> !isdual(space(B, x)), pB[1]),
                                        filter(x -> isdual(space(B, x)), pB[2])))
@@ -78,8 +77,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
             ipB = (invperm(linearize(pB)), ())
             conjΔC = conjB
             conjA′ = conjB ? conjA : !conjA
-            _dB = zerovector(B,
-                             promote_contract(scalartype(ΔC), scalartype(A), scalartype(α)))
+            _dB = similar(B, promote_contract(scalartype(ΔC), scalartype(A), scalartype(α)))
             tA = twist(A,
                        TupleTools.vcat(filter(x -> isdual(space(A, x)), pA[1]),
                                        filter(x -> !isdual(space(A, x)), pA[2])))
@@ -123,7 +121,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensortrace!),
             ip = invperm((linearize(p)..., q[1]..., q[2]...))
             E = one!(TO.tensoralloc_add(scalartype(A), A, q, conjA))
             twist!(E, filter(x -> !isdual(space(E, x)), codomainind(E)))
-            _dA = zerovector(A, promote_scale(ΔC, α))
+            _dA = similar(A, promote_scale(ΔC, α))
             _dA = tensorproduct!(_dA, ΔC,
                                  (trivtuple(TO.numind(p)), ()), conjA, E,
                                  ((), trivtuple(TO.numind(q))), conjA, (ip, ()),

--- a/ext/TensorKitChainRulesCoreExt/utility.jl
+++ b/ext/TensorKitChainRulesCoreExt/utility.jl
@@ -5,15 +5,16 @@ trivtuple(N) = ntuple(identity, N)
 function _repartition(p::IndexTuple, N₁::Int)
     length(p) >= N₁ ||
         throw(ArgumentError("cannot repartition $(typeof(p)) to $N₁, $(length(p) - N₁)"))
-    return p[1:N₁], p[(N₁ + 1):end]
+    return TupleTools.getindices(p, trivtuple(N₁)),
+           TupleTools.getindices(p, trivtuple(length(p) - N₁) .+ N₁)
 end
 _repartition(p::Index2Tuple, N₁::Int) = _repartition(linearize(p), N₁)
 function _repartition(p::Union{IndexTuple,Index2Tuple}, ::Index2Tuple{N₁}) where {N₁}
     return _repartition(p, N₁)
 end
 function _repartition(p::Union{IndexTuple,Index2Tuple},
-                      ::AbstractTensorMap{<:Any,N₁}) where {N₁}
-    return _repartition(p, N₁)
+                      t::AbstractTensorMap)
+    return _repartition(p, TensorKit.numout(t))
 end
 
 TensorKit.block(t::ZeroTangent, c::Sector) = t

--- a/ext/TensorKitChainRulesCoreExt/utility.jl
+++ b/ext/TensorKitChainRulesCoreExt/utility.jl
@@ -2,13 +2,15 @@
 # -------
 trivtuple(N) = ntuple(identity, N)
 
-function _repartition(p::IndexTuple, N₁::Int)
+Base.@constprop :aggressive function _repartition(p::IndexTuple, N₁::Int)
     length(p) >= N₁ ||
         throw(ArgumentError("cannot repartition $(typeof(p)) to $N₁, $(length(p) - N₁)"))
     return TupleTools.getindices(p, trivtuple(N₁)),
            TupleTools.getindices(p, trivtuple(length(p) - N₁) .+ N₁)
 end
-_repartition(p::Index2Tuple, N₁::Int) = _repartition(linearize(p), N₁)
+Base.@constprop :aggressive function _repartition(p::Index2Tuple, N₁::Int)
+    return _repartition(linearize(p), N₁)
+end
 function _repartition(p::Union{IndexTuple,Index2Tuple}, ::Index2Tuple{N₁}) where {N₁}
     return _repartition(p, N₁)
 end

--- a/test/bugfixes.jl
+++ b/test/bugfixes.jl
@@ -44,6 +44,7 @@
         tensorfree!(t2)
     end
 
+    # https://github.com/Jutho/TensorKit.jl/issues/201
     @testset "Issue #201" begin
         function f(A::AbstractTensorMap)
             U, S, V, = tsvd(A)
@@ -72,6 +73,7 @@
         @test convert(Array, grad3) ≈ grad4
     end
 
+    # https://github.com/Jutho/TensorKit.jl/issues/209
     @testset "Issue #209" begin
         function f(T, D)
             @tensor T[1, 4, 1, 3] * D[3, 4]

--- a/test/bugfixes.jl
+++ b/test/bugfixes.jl
@@ -71,4 +71,16 @@
         grad4, = Zygote.gradient(g, convert(Array, B₀))
         @test convert(Array, grad3) ≈ grad4
     end
+
+    @testset "Issue #209" begin
+        function f(T, D)
+            @tensor T[1, 4, 1, 3] * D[3, 4]
+        end
+        V = Z2Space(2, 2)
+        D = DiagonalTensorMap(randn(4), V)
+        T = randn(V ⊗ V ← V ⊗ V)
+        g1, = Zygote.gradient(f, T, D)
+        g2, = Zygote.gradient(f, T, TensorMap(D))
+        @test g1 ≈ g2
+    end
 end


### PR DESCRIPTION
Rewrites these rules in terms of `similar` instead of `zerovector` to ensure first contracting, then projecting onto a diagonal input.

Fixes #209 