### PR TITLE
Add DiagonalTensorMap constructors and converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 A Julia package for large-scale tensor computations, with a hint of category theory.
 
-|                             **Documentation**                             |                       **Digital Object Identifier**                       |                         **Downloads**                         |
-| :-----------------------------------------------------------------------: | :-----------------------------------------------------------------------: | :-----------------------------------------------------------: |
-| [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] |                        [![DOI][doi-img]][doi-url]                         | [![TensorOperations Downloads][downloads-img]][downloads-url] |
-|                                   <!--                                    | [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] |                  [![DOI][doi-img]][doi-url]                   | [![TensorOperations Downloads][downloads-img]][downloads-url] | --> |
+| **Documentation** | **Digital Object Identifier** | **Downloads** |
+|:-----------------:|:-----------------------------:|:-------------:|
+| [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![DOI][doi-img]][doi-url] | [![TensorOperations Downloads][downloads-img]][downloads-url] |
+<!-- | [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![DOI][doi-img]][doi-url] | [![TensorOperations Downloads][downloads-img]][downloads-url] | -->
 
-|    **Build Status**     |              **Coverage**              |      **Quality assurance**       |
-| :---------------------: | :------------------------------------: | :------------------------------: |
+| **Build Status** | **Coverage** | **Quality assurance** |
+|:----------------:|:------------:|:---------------------:|
 | [![CI][ci-img]][ci-url] | [![Codecov][codecov-img]][codecov-url] | [![Aqua QA][aqua-img]][aqua-url] |
 
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 A Julia package for large-scale tensor computations, with a hint of category theory.
 
-| **Documentation** | **Digital Object Identifier** | **Downloads** |
-|:-----------------:|:-----------------------------:|:-------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![DOI][doi-img]][doi-url] | [![TensorOperations Downloads][downloads-img]][downloads-url] |
-<!-- | [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![DOI][doi-img]][doi-url] | [![TensorOperations Downloads][downloads-img]][downloads-url] | -->
+|                             **Documentation**                             |                       **Digital Object Identifier**                       |                         **Downloads**                         |
+| :-----------------------------------------------------------------------: | :-----------------------------------------------------------------------: | :-----------------------------------------------------------: |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] |                        [![DOI][doi-img]][doi-url]                         | [![TensorOperations Downloads][downloads-img]][downloads-url] |
+|                                   <!--                                    | [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] |                  [![DOI][doi-img]][doi-url]                   | [![TensorOperations Downloads][downloads-img]][downloads-url] | --> |
 
-| **Build Status** | **Coverage** | **Quality assurance** |
-|:----------------:|:------------:|:---------------------:|
+|    **Build Status**     |              **Coverage**              |      **Quality assurance**       |
+| :---------------------: | :------------------------------------: | :------------------------------: |
 | [![CI][ci-img]][ci-url] | [![Codecov][codecov-img]][codecov-url] | [![Aqua QA][aqua-img]][aqua-url] |
 
 
@@ -89,16 +89,18 @@ Major non-breaking changes include:
 
 ### Transferring `TensorMap` data from older versions to v0.13:
 
-To export `TensorMap` data from TensorKit.jl v0.12.7 or earlier, you should first export the
-data there in a format that is explicit about how tensor data is associated with the
-structural part of the tensor, i.e. the splitting and fusion tree pairs. Therefore, on the 
-older version of TensorKit.jl, use the following code to save the data
+To export `TensorMap` data from TensorKit.jl v0.12.7 or earlier, please use a format that is explicit about all "blocks" of the tensor, i.e. all coupled sectors and their corresponding matrix blocks. Therefore, on the 
+older version of TensorKit.jl, use the following code to save the data:
 
 ```julia
 using JLD2
 filename = "choose_some_filename.jld2"
-t_dict = Dict(:space => space(t), :data => Dict((f₁, f₂) => t[f₁, f₂] for (f₁, f₂) in fusiontrees(t)))
-jldsave(filename; t_dict)
+t_dict = Dict(
+    :codomain => repr(codomain(t)),
+    :domain => repr(domain(t)),
+    :data => Dict(repr(c) => Array(b) for (c, b) in blocks(t))
+)
+save_object(filename, t_dict)
 ```
 
 If you have already upgraded to TensorKit.jl v0.13, you can still install the old version in
@@ -123,12 +125,7 @@ data and reconstruct the tensor as follows:
 ```julia
 using JLD2
 filename = "choose_some_filename.jld2"
-t_dict = jldload(filename)
-T = eltype(valtype(t_dict[:data]))
-t = TensorMap{T}(undef, t_dict[:space])
-for ((f₁, f₂), val) in t_dict[:data]
-    t[f₁, f₂] .= val
-end
+t = convert(TensorMap, load_object(filename))
 ```
 
 ## Overview
@@ -136,7 +133,7 @@ end
 TensorKit.jl is a package that provides types and methods to represent and manipulate
 tensors with symmetries. The emphasis is on the structure and functionality needed to build
 tensor network algorithms for the simulation of quantum many-body systems. Such tensors are
-typically invariant under a symmetry group which acts via specific representions on each of
+typically invariant under a symmetry group which acts via specific representations on each of
 the indices of the tensor. TensorKit.jl provides the functionality for constructing such
 tensors and performing typical operations such as tensor contractions and decompositions,
 thereby preserving the symmetries and exploiting them for optimal performance.

--- a/README.md
+++ b/README.md
@@ -89,19 +89,17 @@ Major non-breaking changes include:
 
 ### Transferring `TensorMap` data from older versions to v0.13:
 
-To export `TensorMap` data from TensorKit.jl v0.12.7 or earlier, please use a format that is explicit about all "blocks" of the tensor, i.e. all coupled sectors and their corresponding matrix blocks. Therefore, on the 
-older version of TensorKit.jl, use the following code to save the data:
+To export `TensorMap` data from TensorKit.jl v0.12.7 or earlier, you should first export the
+data there in a format that is explicit about how tensor data is associated with the
+structural part of the tensor, i.e. the splitting and fusion tree pairs. Therefore, on the 
+older version of TensorKit.jl, use the following code to save the data
 
-```julia
-using JLD2
-filename = "choose_some_filename.jld2"
-t_dict = Dict(
-    :codomain => repr(codomain(t)),
-    :domain => repr(domain(t)),
-    :data => Dict(repr(c) => Array(b) for (c, b) in blocks(t))
-)
-save_object(filename, t_dict)
-```
+ ```julia
+ using JLD2
+ filename = "choose_some_filename.jld2"
+ t_dict = Dict(:space => space(t), :data => Dict((f₁, f₂) => t[f₁, f₂] for (f₁, f₂) in fusiontrees(t)))
+ jldsave(filename; t_dict)
+ ```
 
 If you have already upgraded to TensorKit.jl v0.13, you can still install the old version in
 a separate environment, for example a temporary environment. To do this, run

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ data there in a format that is explicit about how tensor data is associated with
 structural part of the tensor, i.e. the splitting and fusion tree pairs. Therefore, on the 
 older version of TensorKit.jl, use the following code to save the data
 
- ```julia
- using JLD2
- filename = "choose_some_filename.jld2"
- t_dict = Dict(:space => space(t), :data => Dict((f₁, f₂) => t[f₁, f₂] for (f₁, f₂) in fusiontrees(t)))
- jldsave(filename; t_dict)
- ```
+```julia
+using JLD2
+filename = "choose_some_filename.jld2"
+t_dict = Dict(:space => space(t), :data => Dict((f₁, f₂) => t[f₁, f₂] for (f₁, f₂) in fusiontrees(t)))
+jldsave(filename; t_dict)
+```
 
 If you have already upgraded to TensorKit.jl v0.13, you can still install the old version in
 a separate environment, for example a temporary environment. To do this, run
@@ -123,7 +123,12 @@ data and reconstruct the tensor as follows:
 ```julia
 using JLD2
 filename = "choose_some_filename.jld2"
-t = convert(TensorMap, load_object(filename))
+t_dict = jldload(filename)
+T = eltype(valtype(t_dict[:data]))
+t = TensorMap{T}(undef, t_dict[:space])
+for ((f₁, f₂), val) in t_dict[:data]
+    t[f₁, f₂] .= val
+end
 ```
 
 ## Overview

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -91,6 +91,9 @@ end
 function Base.convert(D::Type{<:DiagonalTensorMap}, d::DiagonalTensorMap)
     return DiagonalTensorMap(convert(storagetype(D), d.data), d.domain)
 end
+function Base.convert(::Type{DiagonalTensorMap}, d::Dict{Symbol,Any})
+    return convert(DiagonalTensorMap, convert(TensorMap, d))
+end
 
 # Complex, real and imaginary parts
 #-----------------------------------

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -52,6 +52,15 @@ function DiagonalTensorMap(data::DenseVector{T}, V::IndexSpace) where {T}
     return DiagonalTensorMap{T}(data, V)
 end
 
+function DiagonalTensorMap(t::AbstractTensorMap)
+    isa(t, DiagonalTensorMap) && return t
+    @assert domain(t) == codomain(t) "Domain and codomain of the input tensor are different."
+    @assert numin(t) == numout(t) == 1 "Domain and codomain of the input tensor are not an IndexSpace."
+    @assert all(Diagonal(b) == b for (k, b) in blocks(t)) "Input tensor is not diagonal."
+    data = vcat((LinearAlgebra.diag(b) for (k, b) in blocks(t))...)
+    return DiagonalTensorMap(data, space(t, 1))
+end
+
 # TODO: more constructors needed?
 
 # Special case adjoint:

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -54,8 +54,10 @@ end
 
 function DiagonalTensorMap(t::AbstractTensorMap{T,S,1,1}) where {T,S}
     isa(t, DiagonalTensorMap) && return t
-    @assert domain(t) == codomain(t) "Domain and codomain of the input tensor are different."
-    @assert all(Diagonal(b) == b for (k, b) in blocks(t)) "Input tensor is not diagonal."
+    domain(t) == codomain(t) ||
+        throw(SpaceMismatch("DiagonalTensorMap requires equal domain and codomain"))
+    all(LinearAlgebra.isdiag ∘ last, blocks(t)) ||
+        throw(ArgumentError("DiagonalTensorMap requires input tensor that is diagonal"))
     data = vcat((LinearAlgebra.diag(b) for (k, b) in blocks(t))...)
     return DiagonalTensorMap(data, space(t, 1))
 end

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -87,13 +87,10 @@ end
 TensorMap(d::DiagonalTensorMap) = copy!(similar(d), d)
 Base.convert(::Type{TensorMap}, d::DiagonalTensorMap) = TensorMap(d)
 
-function Base.convert(::Type{DiagonalTensorMap{T,S,A}},
-                      d::DiagonalTensorMap{T,S,A}) where {T,S,A}
-    return d
-end
 function Base.convert(D::Type{<:DiagonalTensorMap}, d::DiagonalTensorMap)
-    return DiagonalTensorMap(convert(storagetype(D), d.data), d.domain)
+    return (d isa D) ? d : DiagonalTensorMap(convert(storagetype(D), d.data), d.domain)
 end
+Base.convert(::Type{DiagonalTensorMap}, t::DiagonalTensorMap) = t
 function Base.convert(::Type{DiagonalTensorMap}, t::AbstractTensorMap)
     LinearAlgebra.isdiag(t) ||
         throw(ArgumentError("DiagonalTensorMap requires input tensor that is diagonal"))

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -95,7 +95,7 @@ function Base.convert(D::Type{<:DiagonalTensorMap}, d::DiagonalTensorMap)
     return DiagonalTensorMap(convert(storagetype(D), d.data), d.domain)
 end
 function Base.convert(::Type{DiagonalTensorMap}, t::AbstractTensorMap)
-    all(LinearAlgebra.isdiag ∘ last, blocks(t)) ||
+    LinearAlgebra.isdiag(t) ||
         throw(ArgumentError("DiagonalTensorMap requires input tensor that is diagonal"))
     return DiagonalTensorMap(t)
 end

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -63,7 +63,7 @@ function DiagonalTensorMap(t::AbstractTensorMap{T,S,1,1}) where {T,S}
         # TODO: rewrite in terms of `diagview` from MatrixAlgebraKit.jl
         copy!(b.diag, view(bt, LinearAlgebra.diagind(bt)))
     end
-    return t
+    return d
 end
 
 # TODO: more constructors needed?

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -56,10 +56,14 @@ function DiagonalTensorMap(t::AbstractTensorMap{T,S,1,1}) where {T,S}
     isa(t, DiagonalTensorMap) && return t
     domain(t) == codomain(t) ||
         throw(SpaceMismatch("DiagonalTensorMap requires equal domain and codomain"))
-    all(LinearAlgebra.isdiag ∘ last, blocks(t)) ||
-        throw(ArgumentError("DiagonalTensorMap requires input tensor that is diagonal"))
-    data = vcat((LinearAlgebra.diag(b) for (k, b) in blocks(t))...)
-    return DiagonalTensorMap(data, space(t, 1))
+    A = storagetype(t)
+    d = DiagonalTensorMap{T,S,A}(undef, space(t, 1))
+    for (c, b) in blocks(d)
+        bt = block(t, c)
+        # TODO: rewrite in terms of `diagview` from MatrixAlgebraKit.jl
+        copy!(b.diag, view(bt, LinearAlgebra.diagind(bt)))
+    end
+    return t
 end
 
 # TODO: more constructors needed?
@@ -82,7 +86,6 @@ function Base.copy!(t::AbstractTensorMap, d::DiagonalTensorMap)
 end
 TensorMap(d::DiagonalTensorMap) = copy!(similar(d), d)
 Base.convert(::Type{TensorMap}, d::DiagonalTensorMap) = TensorMap(d)
-Base.convert(::Type{DiagonalTensorMap}, t::AbstractTensorMap) = DiagonalTensorMap(t)
 
 function Base.convert(::Type{DiagonalTensorMap{T,S,A}},
                       d::DiagonalTensorMap{T,S,A}) where {T,S,A}
@@ -90,6 +93,11 @@ function Base.convert(::Type{DiagonalTensorMap{T,S,A}},
 end
 function Base.convert(D::Type{<:DiagonalTensorMap}, d::DiagonalTensorMap)
     return DiagonalTensorMap(convert(storagetype(D), d.data), d.domain)
+end
+function Base.convert(::Type{DiagonalTensorMap}, t::AbstractTensorMap)
+    all(LinearAlgebra.isdiag ∘ last, blocks(t)) ||
+        throw(ArgumentError("DiagonalTensorMap requires input tensor that is diagonal"))
+    return DiagonalTensorMap(t)
 end
 function Base.convert(::Type{DiagonalTensorMap}, d::Dict{Symbol,Any})
     return convert(DiagonalTensorMap, convert(TensorMap, d))

--- a/src/tensors/diagonal.jl
+++ b/src/tensors/diagonal.jl
@@ -52,10 +52,9 @@ function DiagonalTensorMap(data::DenseVector{T}, V::IndexSpace) where {T}
     return DiagonalTensorMap{T}(data, V)
 end
 
-function DiagonalTensorMap(t::AbstractTensorMap)
+function DiagonalTensorMap(t::AbstractTensorMap{T,S,1,1}) where {T,S}
     isa(t, DiagonalTensorMap) && return t
     @assert domain(t) == codomain(t) "Domain and codomain of the input tensor are different."
-    @assert numin(t) == numout(t) == 1 "Domain and codomain of the input tensor are not an IndexSpace."
     @assert all(Diagonal(b) == b for (k, b) in blocks(t)) "Input tensor is not diagonal."
     data = vcat((LinearAlgebra.diag(b) for (k, b) in blocks(t))...)
     return DiagonalTensorMap(data, space(t, 1))
@@ -81,6 +80,7 @@ function Base.copy!(t::AbstractTensorMap, d::DiagonalTensorMap)
 end
 TensorMap(d::DiagonalTensorMap) = copy!(similar(d), d)
 Base.convert(::Type{TensorMap}, d::DiagonalTensorMap) = TensorMap(d)
+Base.convert(::Type{DiagonalTensorMap}, t::AbstractTensorMap) = DiagonalTensorMap(t)
 
 function Base.convert(::Type{DiagonalTensorMap{T,S,A}},
                       d::DiagonalTensorMap{T,S,A}) where {T,S,A}

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -395,9 +395,10 @@ Base.copy(t::TensorMap) = typeof(t)(copy(t.data), t.space)
 # Conversion between TensorMap and Dict, for read and write purpose
 #------------------------------------------------------------------
 function Base.convert(::Type{Dict}, t::AbstractTensorMap)
-    return Dict(:codomain => repr(codomain(t)),
-                :domain => repr(domain(t)),
-                :data => Dict(repr(c) => Array(b) for (c, b) in blocks(t)))
+    return Dict{Symbol,Any}(:codomain => repr(codomain(t)),
+                            :domain => repr(domain(t)),
+                            :data => Dict{String,Any}(repr(c) => Array(b)
+                                                      for (c, b) in blocks(t)))
 end
 function Base.convert(::Type{TensorMap}, d::Dict{Symbol,Any})
     try
@@ -411,6 +412,9 @@ function Base.convert(::Type{TensorMap}, d::Dict{Symbol,Any})
         data = SectorDict(Base.eval(Main, Meta.parse(c)) => b for (c, b) in d[:data])
         return TensorMap(data, codomain, domain)
     end
+end
+function Base.convert(::Type{DiagonalTensorMap}, d::Dict{Symbol,Any})
+    return convert(DiagonalTensorMap, convert(TensorMap, d))
 end
 
 # Getting and setting the data at the block level

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -413,9 +413,6 @@ function Base.convert(::Type{TensorMap}, d::Dict{Symbol,Any})
         return TensorMap(data, codomain, domain)
     end
 end
-function Base.convert(::Type{DiagonalTensorMap}, d::Dict{Symbol,Any})
-    return convert(DiagonalTensorMap, convert(TensorMap, d))
-end
 
 # Getting and setting the data at the block level
 #-------------------------------------------------

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -395,10 +395,15 @@ Base.copy(t::TensorMap) = typeof(t)(copy(t.data), t.space)
 # Conversion between TensorMap and Dict, for read and write purpose
 #------------------------------------------------------------------
 function Base.convert(::Type{Dict}, t::AbstractTensorMap)
-    return Dict{Symbol,Any}(:codomain => repr(codomain(t)),
-                            :domain => repr(domain(t)),
-                            :data => Dict{String,Any}(repr(c) => Array(b)
-                                                      for (c, b) in blocks(t)))
+    d = Dict{Symbol,Any}()
+    d[:codomain] = repr(codomain(t))
+    d[:domain] = repr(domain(t))
+    data = Dict{String,Any}()
+    for (c, b) in blocks(t)
+        data[repr(c)] = Array(b)
+    end
+    d[:data] = data
+    return d
 end
 function Base.convert(::Type{TensorMap}, d::Dict{Symbol,Any})
     try

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -395,15 +395,9 @@ Base.copy(t::TensorMap) = typeof(t)(copy(t.data), t.space)
 # Conversion between TensorMap and Dict, for read and write purpose
 #------------------------------------------------------------------
 function Base.convert(::Type{Dict}, t::AbstractTensorMap)
-    d = Dict{Symbol,Any}()
-    d[:codomain] = repr(codomain(t))
-    d[:domain] = repr(domain(t))
-    data = Dict{String,Any}()
-    for (c, b) in blocks(t)
-        data[repr(c)] = Array(b)
-    end
-    d[:data] = data
-    return d
+    return Dict(:codomain => repr(codomain(t)),
+                :domain => repr(domain(t)),
+                :data => Dict(repr(c) => Array(b) for (c, b) in blocks(t)))
 end
 function Base.convert(::Type{TensorMap}, d::Dict{Symbol,Any})
     try

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -89,9 +89,14 @@ diagspacelist = ((ℂ^4)', ℂ[Z2Irrep](0 => 2, 1 => 3),
     @timedtestset "Tensor conversion" begin
         t = @constinferred DiagonalTensorMap(undef, V)
         rand!(t.data)
+        # element type conversion
         tc = complex(t)
         @test convert(typeof(tc), t) == tc
         @test typeof(convert(typeof(tc), t)) == typeof(tc)
+        # to and from generic TensorMap
+        td = DiagonalTensorMap(TensorMap(t))
+        @test t == td
+        @test typeof(td) == typeof(t)
     end
     I = sectortype(V)
     if BraidingStyle(I) isa SymmetricBraiding


### PR DESCRIPTION
Changes:

- In README guide of transferring data from old to new TensorKit, ~the old data is now specified by `blocks` instead of `fusiontrees`~.
- Added the conversion from a TensorMap to a DiagonalTensorMap. It first checks if the input is indeed diagonal. 