### PR TITLE
Add rrule for matrix exponential

### DIFF
--- a/test/ad.jl
+++ b/test/ad.jl
@@ -173,6 +173,7 @@ Vlist = ((ℂ^2, (ℂ^3)', ℂ^3, ℂ^2, (ℂ^2)'),
         for i in 1:3
             E = randn(T, ⊗(V[1:i]...) ← ⊗(V[1:i]...))
             test_rrule(LinearAlgebra.tr, E)
+            test_rrule(exp, E; check_inferred=false)
         end
 
         A = randn(T, V[1] ⊗ V[2] ← V[3] ⊗ V[4] ⊗ V[5])


### PR DESCRIPTION
This uses the pullback of the blocks to promote it to a pullback of the entire tensor. Sadly, the implementation of ChainRules.jl is not type stable since it is checking at runtime if the matrices are Hermitian, so the `rrule` is also not type stable (the pullback itself is type stable however).

Fixes #213 