### PR TITLE
Nightly tests don't count as failed CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,6 @@ jobs:
     name: Julia nightly - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         version:
           - 'nightly'
@@ -65,6 +64,7 @@ jobs:
           - windows-latest
         arch:
           - x64
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
This should change the CI such that failures on nightly no longer count as a failed test (thus avoiding the red cross)