### PR TITLE
Fix QR and LQ pullback for rank 0 blocks

### DIFF
--- a/ext/TensorKitChainRulesCoreExt/factorizations.jl
+++ b/ext/TensorKitChainRulesCoreExt/factorizations.jl
@@ -376,7 +376,7 @@ end
 function qr_pullback!(ΔA::AbstractMatrix, Q::AbstractMatrix, R::AbstractMatrix, ΔQ, ΔR;
                       tol::Real=default_pullback_gaugetol(R))
     Rd = view(R, diagind(R))
-    p = searchsortedlast(Rd, tol; by=abs, rev=true)
+    p = something(findlast(≥(tol) ∘ abs, Rd), 0)
     m, n = size(R)
 
     Q1 = view(Q, :, 1:p)
@@ -427,7 +427,7 @@ end
 function lq_pullback!(ΔA::AbstractMatrix, L::AbstractMatrix, Q::AbstractMatrix, ΔL, ΔQ;
                       tol::Real=default_pullback_gaugetol(L))
     Ld = view(L, diagind(L))
-    p = searchsortedlast(Ld, tol; by=abs, rev=true)
+    p = something(findlast(≥(tol) ∘ abs, Ld), 0)
     m, n = size(L)
 
     L1 = view(L, :, 1:p)

--- a/ext/TensorKitChainRulesCoreExt/factorizations.jl
+++ b/ext/TensorKitChainRulesCoreExt/factorizations.jl
@@ -219,7 +219,7 @@ function svd_pullback!(ΔA::AbstractMatrix, U::AbstractMatrix, S::AbstractVector
     Sp = view(S, 1:p)
 
     # rank
-    r = count(>(tol), S)
+    r = searchsortedlast(S, tol; rev=true)
 
     # compute antihermitian part of projection of ΔU and ΔV onto U and V
     # also already subtract this projection from ΔU and ΔV
@@ -376,7 +376,7 @@ end
 function qr_pullback!(ΔA::AbstractMatrix, Q::AbstractMatrix, R::AbstractMatrix, ΔQ, ΔR;
                       tol::Real=default_pullback_gaugetol(R))
     Rd = view(R, diagind(R))
-    p = count(>=(tol) ∘ abs, Rd)
+    p = searchsortedlast(Rd, tol; by=abs, rev=true)
     m, n = size(R)
 
     Q1 = view(Q, :, 1:p)
@@ -427,7 +427,7 @@ end
 function lq_pullback!(ΔA::AbstractMatrix, L::AbstractMatrix, Q::AbstractMatrix, ΔL, ΔQ;
                       tol::Real=default_pullback_gaugetol(L))
     Ld = view(L, diagind(L))
-    p = count(>=(tol) ∘ abs, Ld)
+    p = searchsortedlast(Ld, tol; by=abs, rev=true)
     m, n = size(L)
 
     L1 = view(L, :, 1:p)

--- a/ext/TensorKitChainRulesCoreExt/factorizations.jl
+++ b/ext/TensorKitChainRulesCoreExt/factorizations.jl
@@ -376,7 +376,7 @@ end
 function qr_pullback!(ΔA::AbstractMatrix, Q::AbstractMatrix, R::AbstractMatrix, ΔQ, ΔR;
                       tol::Real=default_pullback_gaugetol(R))
     Rd = view(R, diagind(R))
-    p = findlast(>=(tol) ∘ abs, Rd)
+    p = count(>=(tol) ∘ abs, Rd)
     m, n = size(R)
 
     Q1 = view(Q, :, 1:p)
@@ -427,7 +427,7 @@ end
 function lq_pullback!(ΔA::AbstractMatrix, L::AbstractMatrix, Q::AbstractMatrix, ΔL, ΔQ;
                       tol::Real=default_pullback_gaugetol(L))
     Ld = view(L, diagind(L))
-    p = findlast(>=(tol) ∘ abs, Ld)
+    p = count(>=(tol) ∘ abs, Ld)
     m, n = size(L)
 
     L1 = view(L, :, 1:p)


### PR DESCRIPTION
This fixes #222 similar to #219 .

I was looking at this and realized that there is also `searchsortedlast`, which would do the trick as well (probably slightly more efficiently) through a binary search. I just don't know if it's worth the extra complexity of thinking about what are the correct arguments to that function so I just left it at `count`. Maybe we can consider this in the MatrixAlgebraKit implementation?