### PR TITLE
Replace `c == one(I)` with `isone(c)`

### DIFF
--- a/src/fusiontrees/fusiontrees.jl
+++ b/src/fusiontrees/fusiontrees.jl
@@ -235,13 +235,13 @@ include("iterator.jl")
 # _abelianinner: generate the inner indices for given outer indices in the abelian case
 _abelianinner(outer::Tuple{}) = ()
 function _abelianinner(outer::Tuple{I}) where {I<:Sector}
-    return outer[1] == one(I) ? () : throw(SectorMismatch())
+    return isone(outer[1]) ? () : throw(SectorMismatch())
 end
 function _abelianinner(outer::Tuple{I,I}) where {I<:Sector}
     return outer[1] == dual(outer[2]) ? () : throw(SectorMismatch())
 end
 function _abelianinner(outer::Tuple{I,I,I}) where {I<:Sector}
-    return first(⊗(outer...)) == one(I) ? () : throw(SectorMismatch())
+    return isone(first(⊗(outer...))) ? () : throw(SectorMismatch())
 end
 function _abelianinner(outer::Tuple{I,I,I,I,Vararg{I}}) where {I<:Sector}
     c = first(outer[1] ⊗ outer[2])

--- a/src/fusiontrees/iterator.jl
+++ b/src/fusiontrees/iterator.jl
@@ -37,7 +37,7 @@ Base.IteratorEltype(::FusionTreeIterator) = Base.HasEltype()
 Base.eltype(::Type{<:FusionTreeIterator{I,N}}) where {I<:Sector,N} = fusiontreetype(I, N)
 
 Base.length(iter::FusionTreeIterator) = _fusiondim(iter.uncouplediterators, iter.coupled)
-_fusiondim(::Tuple{}, c::I) where {I<:Sector} = Int(one(c) == c)
+_fusiondim(::Tuple{}, c::I) where {I<:Sector} = Int(isone(c))
 _fusiondim(iters::NTuple{1}, c::I) where {I<:Sector} = Int(c ∈ iters[1])
 function _fusiondim(iters::NTuple{2}, c::I) where {I<:Sector}
     d = 0
@@ -60,9 +60,9 @@ end
 # * Iterator methods:
 #   Start with special cases:
 function Base.iterate(it::FusionTreeIterator{I,0},
-                      state=(it.coupled != one(I))) where {I<:Sector}
+                      state=!isone(it.coupled)) where {I<:Sector}
     state && return nothing
-    tree = FusionTree{I}((), one(I), (), (), ())
+    tree = FusionTree{I}((), it.coupled, (), (), ())
     return tree, true
 end
 


### PR DESCRIPTION
This is a convenience change that should not alter the implementation, but allows multifusion sectors to work better.
Taken from [this fork](https://github.com/borisdevos/TensorKit.jl/tree/Multifusion) of @borisdevos

Co-authored-by: Boris De Vos <boris.devos@ugent.be>