### PR TITLE
Add `complex(::BraidingTensor)` specialization

### DIFF
--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -104,6 +104,11 @@ Base.copy(b::BraidingTensor) = b
 TensorMap(b::BraidingTensor) = copy!(similar(b), b)
 Base.convert(::Type{TensorMap}, b::BraidingTensor) = TensorMap(b)
 
+Base.complex(b::BraidingTensor{<:Complex}) = b
+function Base.complex(b::BraidingTensor)
+    return BraidingTensor{complex(scalartype(b))}(space(b), b.adjoint)
+end
+
 function block(b::BraidingTensor, s::Sector)
     sectortype(b) == typeof(s) || throw(SectorMismatch())
 

--- a/test/planar.jl
+++ b/test/planar.jl
@@ -72,6 +72,8 @@ Vfib = (Vect[FibonacciAnyon](:I => 1, :τ => 2),
         @test_throws SpaceMismatch BraidingTensor(W2)
 
         @test adjoint(t1) isa BraidingTensor
+        @test complex(t1) isa BraidingTensor
+        @test scalartype(complex(t1)) <: Complex
 
         t3 = @inferred TensorMap(t2)
         t4 = braid(id(storagetype(t2), domain(t2)), ((2, 1), (3, 4)), (1, 2, 3, 4))


### PR DESCRIPTION
This is a small utility to make `complex(::BraidingTensor)` return a `BraidingTensor` instead of a `TensorMap`.