### PR TITLE
Replace `isequal` with `==` for `FusionTree`

### DIFF
--- a/src/fusiontrees/fusiontrees.jl
+++ b/src/fusiontrees/fusiontrees.jl
@@ -114,7 +114,7 @@ function Base.hash(f::FusionTree{I}, h::UInt) where {I}
     end
     return h
 end
-function Base.isequal(f₁::FusionTree{I,N}, f₂::FusionTree{I,N}) where {I<:Sector,N}
+function Base.:(==)(f₁::FusionTree{I,N}, f₂::FusionTree{I,N}) where {I<:Sector,N}
     f₁.coupled == f₂.coupled || return false
     @inbounds for i in 1:N
         f₁.uncoupled[i] == f₂.uncoupled[i] || return false
@@ -132,7 +132,7 @@ function Base.isequal(f₁::FusionTree{I,N}, f₂::FusionTree{I,N}) where {I<:Se
     end
     return true
 end
-Base.isequal(f₁::FusionTree, f₂::FusionTree) = false
+Base.:(==)(f₁::FusionTree, f₂::FusionTree) = false
 
 # Facilitate getting correct fusion tree types
 function fusiontreetype(::Type{I}, N::Int) where {I<:Sector}


### PR DESCRIPTION
I ran into an issue where `==(::FusionTree, ::FusionTree)` did not correctly evaluate.
Since it is not defined, it falls back to `===`, which has not caused any problems for us because all our sectors are `isbits`, however this fails when this is not the case.
(In this case, we (@Yue-Zhengyuan and I) are using a `Vector{Int}` to store the partition of `N` for an `S3Irrep`).
In principle, we can work around this and not have vectors, or locally change it, but this seems like a bug that should be solved.

From the documentation of Base, it seems like we should simply define `==` instead of `isequal` for fusiontrees, because we are not dealing with floating point values. `isequal` should then fall back to `==`. Am I missing some performance implications here, or is this simply an oversight?