### PR TITLE
Improve error handling for tensor functions

### DIFF
--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -444,7 +444,7 @@ for f in (:cos, :sin, :tan, :cot, :cosh, :sinh, :tanh, :coth, :atan, :acot, :asi
     sf = string(f)
     @eval function Base.$f(t::AbstractTensorMap)
         domain(t) == codomain(t) ||
-            error("$sf of a tensor only exist when domain == codomain.")
+            throw(SpaceMismatch("`$($sf)` of a tensor only exist when domain == codomain"))
         T = float(scalartype(t))
         tf = similar(t, T)
         if T <: Real
@@ -464,7 +464,7 @@ for f in (:sqrt, :log, :asin, :acos, :acosh, :atanh, :acoth)
     sf = string(f)
     @eval function Base.$f(t::AbstractTensorMap)
         domain(t) == codomain(t) ||
-            error("$($sf) of a tensor only exist when domain == codomain.")
+            throw(SpaceMismatch("`$($sf)` of a tensor only exist when domain == codomain"))
         T = complex(float(scalartype(t)))
         tf = similar(t, T)
         for (c, b) in blocks(t)

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -464,7 +464,7 @@ for f in (:sqrt, :log, :asin, :acos, :acosh, :atanh, :acoth)
     sf = string(f)
     @eval function Base.$f(t::AbstractTensorMap)
         domain(t) == codomain(t) ||
-            error("$sf of a tensor only exist when domain == codomain.")
+            error("$($sf) of a tensor only exist when domain == codomain.")
         T = complex(float(scalartype(t)))
         tf = similar(t, T)
         for (c, b) in blocks(t)

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -668,6 +668,13 @@ for V in spacelist
                     t8 = coth(t)
                     @test coth(@constinferred acoth(t8)) ≈ t8
                 end
+
+                t = randn(T, W, V1) # not square
+                for f in
+                    (cos, sin, tan, cot, cosh, sinh, tanh, coth, atan, acot, asinh, sqrt,
+                     log, asin, acos, acosh, atanh, acoth)
+                    @test_throws SpaceMismatch f(t)
+                end
             end
         end
         @timedtestset "Sylvester equation" begin

--- a/test/tensors.jl
+++ b/test/tensors.jl
@@ -667,13 +667,12 @@ for V in spacelist
                     @test tanh(@constinferred atanh(t7)) ≈ t7
                     t8 = coth(t)
                     @test coth(@constinferred acoth(t8)) ≈ t8
-                end
-
-                t = randn(T, W, V1) # not square
-                for f in
-                    (cos, sin, tan, cot, cosh, sinh, tanh, coth, atan, acot, asinh, sqrt,
-                     log, asin, acos, acosh, atanh, acoth)
-                    @test_throws SpaceMismatch f(t)
+                    t = randn(T, W, V1) # not square
+                    for f in
+                        (cos, sin, tan, cot, cosh, sinh, tanh, coth, atan, acot, asinh,
+                         sqrt, log, asin, acos, acosh, atanh, acoth)
+                        @test_throws SpaceMismatch f(t)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Refactor error messages to throw a `SpaceMismatch` and fix the nested interpolation.

Fixes #237