### PR TITLE
Allow twisting of trivial sectors without restrictions

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -29,7 +29,7 @@ jobs:
         #
         # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1"))'
           julia  -e 'using JuliaFormatter; format(".", verbose=true)'
       - name: Format check
         run: |

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -272,6 +272,13 @@ function twist!(t::AbstractTensorMap, is; inv::Bool=false)
         throw(ArgumentError(msg))
     end
     (BraidingStyle(sectortype(t)) == Bosonic() || isempty(is)) && return t
+    if BraidingStyle(sectortype(t)) == NoBraiding()
+        for i in is
+            cs = sectors(space(t, i))
+            all(isone, cs) || throw(SectorMismatch(lazy"Cannot twist sectors $cs"))
+        end
+        return t
+    end
     N₁ = numout(t)
     for (f₁, f₂) in fusiontrees(t)
         θ = prod(i -> i <= N₁ ? twist(f₁.uncoupled[i]) : twist(f₂.uncoupled[i - N₁]), is)


### PR DESCRIPTION
Enable twisting of trivial sectors in cases where no braiding is defined, similar to how braiding trivial sectors is special cased.

Fixes #239