### PR TITLE
export `sectorscalartype`

### DIFF
--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -39,7 +39,7 @@ export infimum, supremum, isisomorphic, ismonomorphic, isepimorphic
 
 # methods for sectors and properties thereof
 export sectortype, sectors, hassector, Nsymbol, Fsymbol, Rsymbol, Bsymbol,
-       frobeniusschur, twist, otimes
+       frobeniusschur, twist, otimes, sectorscalartype
 export fusiontrees, braid, permute, transpose
 export ZNSpace, SU2Irrep, U1Irrep, CU1Irrep
 # other fusion tree manipulations, should not be exported:


### PR DESCRIPTION
This is to allow `BlockTensorKit` to also use this function