### PR TITLE
Change frobeniusschur factor

### DIFF
--- a/src/fusiontrees/manipulations.jl
+++ b/src/fusiontrees/manipulations.jl
@@ -347,7 +347,7 @@ function foldright(f₁::FusionTree{I,N₁}, f₂::FusionTree{I,N₂}) where {I<
     isduala = f₁.isdual[1]
     factor = sqrtdim(a)
     if !isduala
-        factor *= frobeniusschur(a)
+        factor *= conj(frobeniusschur(a))
     end
     c1 = dual(a)
     c2 = f₁.coupled


### PR DESCRIPTION
This is a small change that fixes some issues encountered with transposing and adjoints not commuting. We've traced the origin to being that while we aren't assuming the Frobenius Schur factor is +-1, we have no checks for that since for all our sectors this is true.

There is definitely a `conj` missing, and the one I added here seems to resolve the issue, but I absolutely did not think through whether or not it should be here, or here instead:

https://github.com/Jutho/TensorKit.jl/blob/ef03d19f8add057074c8103470dc15d759e8cd43/src/fusiontrees/manipulations.jl#L309