### PR TITLE
Bump VectorInterface compat to `0.4.8, 0.5`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ TensorOperations = "5.1"
 Test = "1"
 TestExtras = "0.2,0.3"
 TupleTools = "1.1"
-VectorInterface = "0.4, 0.5"
+VectorInterface = "0.4.8, 0.5"
 Zygote = "0.7"
 julia = "1.10"
 


### PR DESCRIPTION
This ensures the minimal compat tests don't run into the VectorInterface 0.4 resolved issues.