### PR TITLE
Make `truncspace` explanation more specific

### DIFF
--- a/docs/src/man/tensors.md
+++ b/docs/src/man/tensors.md
@@ -946,8 +946,8 @@ the keyword argument `p`. The default value `notrunc()` implies no truncation, a
 *   `truncdim(χ::Integer)`: finds the optimal truncation such that the equivalent total
     dimension of the internal vector space is no larger than `χ`;
 
-*   `truncspace(W)`: truncates such that the dimension of the internal vector space is
-    smaller than or equal to that of `W` in any sector, i.e. with
+*   `truncspace(W)`: truncates such that the dimension of the internal vector space is no
+    greater than that of `W` in any sector, i.e. with
     `W₀ = min(fuse(codomain(t)), fuse(domain(t)))` this option will result in
     `domain(U) == domain(Σ) == codomain(Σ) == codomain(Vᵈ) == min(W, W₀)`;
 

--- a/src/tensors/factorizations.jl
+++ b/src/tensors/factorizations.jl
@@ -32,8 +32,8 @@ case a truncated singular value decomposition will be computed. Choices are:
     smaller than `η`;
 *   `truncdim(χ::Int)`: truncates such that the equivalent total dimension of the internal
     vector space is no larger than `χ`;
-*   `truncspace(V)`: truncates such that the dimension of the internal vector space is
-    smaller than or equal to that of `V` in any sector.
+*   `truncspace(V)`: truncates such that the dimension of the internal vector space is no
+    greater than that of `V` in any sector.
 *   `truncbelow(η::Real)`: truncates such that every singular value is larger then `η` ;
 
 Truncation options can also be combined using `&`, i.e. `truncbelow(η) & truncdim(χ)` will


### PR DESCRIPTION
I managed to confuse myself about the intended behavior of the `truncspace` truncation scheme since dimensions were coming out smaller than I expected, and the explanation in the `tsvd` docstring didn't really help. It turned out that the truncation did behave as I would expect, but then the docstring is technically incorrect and a bit confusing.

So, I thought it would be better to make this a bit more specific.