### PR TITLE
rework TensorOperations implementation to use backend and allocator

### DIFF
--- a/src/tensors/tensoroperations.jl
+++ b/src/tensors/tensoroperations.jl
@@ -339,7 +339,7 @@ function blas_contract!(
     if bstyle isa Fermionic && any(isdual ∘ Base.Fix1(space, B), pB[1])
         # twist smallest object if neither or both already have to be permuted
         # otherwise twist the one that already is copied
-        if copyA ⊻ copyB
+        if !(copyA ⊻ copyB)
             twistA = dim(A) < dim(B)
         else
             twistA = copyA


### PR DESCRIPTION
This removes one of the TODOs by bringing the `contract!` interface more in line with the TensorOperations functionality, which allows us to now use the `backend` and `allocator` functionality a bit more fully.

Additionally, I slightly reworked the logic of surrounding `twist` to avoid some more allocations in some edge cases where we didn't have to permute A, but we did have to twist it.

This is a partial reimplementation of some of the logic in #203 but I kept this PR way more minimal and less opinionated, to already get this merged and then simplify actually looking at the multithreading afterwards.

One other thing I noticed is that our `memcost` checking could use some improvements still: we will never simplify the following case for example, which actually could be implemented as a simple `mul!` call.
```julia
pA = ((3, 2, 1), (4,))
pB = ((1,), (2,))
pAB = ((3, 2, 1), (4,))
```
This however is somewhat related to the planar reorderings that we are doing anyways, so it might actually pay off to at some point (in a separate PR!) have a look at this.