### PR TITLE
`norm` performance optimization

### DIFF
--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -269,8 +269,9 @@ function _norm(blockiter, p::Real, init::Real)
             return isempty(b) ? init : oftype(init, LinearAlgebra.normInf(b))
         end
     elseif p > 0 # finite positive p
-        np = sum(blockiter; init) do (c, b)
-            return oftype(init, dim(c) * norm(b, p)^p)
+        np = init
+        for (c, b) in blockiter
+            np += oftype(init, dim(c) * norm(b, p)^p)
         end
         return np^(inv(oftype(np, p)))
     else


### PR DESCRIPTION
This is a small performance boost for `UniqueFusion` sectors, taking the norm of the parameters directly (and avoiding having to access caches to obtain the blockstructure).
For whatever reason, the usage of `Base.sum` also seems to allocate, and the manual loop does not...