### PR TITLE
Small fix for ignored `adjoint` flag in `BraidingTensor`

### DIFF
--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -99,8 +99,8 @@ function _braiding_factor(f₁, f₂, inv::Bool = false)
     return r
 end
 
-@inline function Base.getindex(
-        b::BraidingTensor, f₁::FusionTree{I, 2}, f₂::FusionTree{I, 2}
+@inline function subblock(
+        b::BraidingTensor, (f₁, f₂)::Tuple{FusionTree{I, 2}, FusionTree{I, 2}}
     ) where {I <: Sector}
     I == sectortype(b) || throw(SectorMismatch())
     c = f₁.coupled
@@ -125,10 +125,6 @@ end
         end
     end
     return data
-end
-@inline function Base.getindex(b::BraidingTensor, ::Nothing, ::Nothing)
-    sectortype(b) === Trivial || throw(SectorMismatch())
-    return getindex(b)
 end
 
 # efficient copy constructor

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -169,7 +169,7 @@ function block(b::BraidingTensor, s::Sector)
 
     for ((f₁, f₂), (sz, str, off)) in pairs(subblockstructure(space(b)))
         (f₁.coupled == f₂.coupled == s) || continue
-        r = _braiding_factor(f₁, f₂)
+        r = _braiding_factor(f₁, f₂, b.adjoint)
         isnothing(r) && continue
         # change offset to account for single block
         subblock = StridedView(data, sz, str, off - base_offset)

--- a/test/tensors/planar.jl
+++ b/test/tensors/planar.jl
@@ -40,6 +40,16 @@ using .TestSetup
         for (f1, f2) in fusiontrees(t1)
             @test t1[f1, f2] ≈ t3[f1, f2]
         end
+
+        t5 = @inferred TensorMap(t2')
+        t6 = braid(id(storagetype(t2), domain(t2')), ((2, 1), (3, 4)), (4, 3, 2, 1))
+        @test t5 ≈ t6
+        for (c, b) in blocks(t1')
+            @test block(t1', c) ≈ b ≈ block(t5, c)
+        end
+        for (f1, f2) in fusiontrees(t1')
+            @test t1'[f1, f2] ≈ t5[f1, f2]
+        end
     end
 end
 


### PR DESCRIPTION
As brought up by @Jutho in previous PR.
This both fixes and adds a test that would have been failing before.