### PR TITLE
define `spacetype` for `TruncationSpace`

### DIFF
--- a/src/factorizations/truncation.jl
+++ b/src/factorizations/truncation.jl
@@ -25,7 +25,7 @@ function truncspace(space::ElementarySpace; by = abs, rev::Bool = true)
     return TruncationSpace(space, by, rev)
 end
 
-spacetype(::Type{<:TruncationSpace{S}}) where {S} = S
+TensorKit.spacetype(::Type{<:TruncationSpace{S}}) where {S} = S
 
 # truncate!
 # ---------

--- a/src/factorizations/truncation.jl
+++ b/src/factorizations/truncation.jl
@@ -259,12 +259,12 @@ MAK.findtruncated_svd(values::SectorVector, strategy::TruncationByError) =
     MAK.findtruncated(values, strategy)
 
 function MAK.findtruncated(values::SectorVector, strategy::TruncationSpace)
-    sectortype(values) == sectortype(strategy) || throw(SpaceMismatch("sectortype of truncation strategy does not match values"))
+    sectortype(values) == sectortype(strategy) || throw(SectorMismatch("sectortype of truncation strategy does not match values"))
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated(d, blockstrategy(c)) for (c, d) in pairs(values))
 end
 function MAK.findtruncated_svd(values::SectorVector, strategy::TruncationSpace)
-    sectortype(values) == sectortype(strategy) || throw(SpaceMismatch("sectortype of truncation strategy does not match values"))
+    sectortype(values) == sectortype(strategy) || throw(SectorMismatch("sectortype of truncation strategy does not match values"))
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated_svd(d, blockstrategy(c)) for (c, d) in pairs(values))
 end

--- a/src/factorizations/truncation.jl
+++ b/src/factorizations/truncation.jl
@@ -259,12 +259,12 @@ MAK.findtruncated_svd(values::SectorVector, strategy::TruncationByError) =
     MAK.findtruncated(values, strategy)
 
 function MAK.findtruncated(values::SectorVector, strategy::TruncationSpace)
-    @assert spacetype(values) == spacetype(strategy)
+    @assert sectortype(values) == sectortype(strategy)
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated(d, blockstrategy(c)) for (c, d) in pairs(values))
 end
 function MAK.findtruncated_svd(values::SectorVector, strategy::TruncationSpace)
-    @assert spacetype(values) == spacetype(strategy)
+    @assert sectortype(values) == sectortype(strategy)
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated_svd(d, blockstrategy(c)) for (c, d) in pairs(values))
 end

--- a/src/factorizations/truncation.jl
+++ b/src/factorizations/truncation.jl
@@ -259,10 +259,12 @@ MAK.findtruncated_svd(values::SectorVector, strategy::TruncationByError) =
     MAK.findtruncated(values, strategy)
 
 function MAK.findtruncated(values::SectorVector, strategy::TruncationSpace)
+    @assert spacetype(values) == spacetype(strategy)
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated(d, blockstrategy(c)) for (c, d) in pairs(values))
 end
 function MAK.findtruncated_svd(values::SectorVector, strategy::TruncationSpace)
+    @assert spacetype(values) == spacetype(strategy)
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated_svd(d, blockstrategy(c)) for (c, d) in pairs(values))
 end

--- a/src/factorizations/truncation.jl
+++ b/src/factorizations/truncation.jl
@@ -25,6 +25,8 @@ function truncspace(space::ElementarySpace; by = abs, rev::Bool = true)
     return TruncationSpace(space, by, rev)
 end
 
+spacetype(::Type{<:TruncationSpace{S}}) where {S} = S
+
 # truncate!
 # ---------
 _blocklength(d::Integer, ind) = _blocklength(Base.OneTo(d), ind)

--- a/src/factorizations/truncation.jl
+++ b/src/factorizations/truncation.jl
@@ -259,12 +259,12 @@ MAK.findtruncated_svd(values::SectorVector, strategy::TruncationByError) =
     MAK.findtruncated(values, strategy)
 
 function MAK.findtruncated(values::SectorVector, strategy::TruncationSpace)
-    @assert sectortype(values) == sectortype(strategy)
+    sectortype(values) == sectortype(strategy) || throw(SpaceMismatch("sectortype of truncation strategy does not match values"))
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated(d, blockstrategy(c)) for (c, d) in pairs(values))
 end
 function MAK.findtruncated_svd(values::SectorVector, strategy::TruncationSpace)
-    @assert sectortype(values) == sectortype(strategy)
+    sectortype(values) == sectortype(strategy) || throw(SpaceMismatch("sectortype of truncation strategy does not match values"))
     blockstrategy(c) = truncrank(dim(strategy.space, c); strategy.by, strategy.rev)
     return SectorDict(c => MAK.findtruncated_svd(d, blockstrategy(c)) for (c, d) in pairs(values))
 end

--- a/test/factorizations/svd.jl
+++ b/test/factorizations/svd.jl
@@ -212,8 +212,8 @@ for V in spacelist
                 @test ϵ1 ≈ ϵ2
 
                 trunc = truncspace(space(S2, 1))
-                @test spacetype(typeof(trunc)) == spacetype(V)
-                @test sectortype(trunc) == sectortype(V)
+                @test spacetype(typeof(trunc)) == spacetype(W)
+                @test sectortype(trunc) == sectortype(W)
                 U3, S3, Vᴴ3, ϵ3 = @constinferred svd_trunc(t; trunc)
                 @test t * Vᴴ3' ≈ U3 * S3
                 @test isisometric(U3)

--- a/test/factorizations/svd.jl
+++ b/test/factorizations/svd.jl
@@ -212,6 +212,8 @@ for V in spacelist
                 @test ϵ1 ≈ ϵ2
 
                 trunc = truncspace(space(S2, 1))
+                @test spacetype(typeof(trunc)) == spacetype(V)
+                @test sectortype(trunc) == sectortype(V)
                 U3, S3, Vᴴ3, ϵ3 = @constinferred svd_trunc(t; trunc)
                 @test t * Vᴴ3' ≈ U3 * S3
                 @test isisometric(U3)


### PR DESCRIPTION
This PR defines `spacetype` for `TruncationSpace` and adds a test that spacetype matches between the vector to truncate and the strategy (else it will crash with a hard to read error). I expect the check to be done at compile time without any consequence on assembly code.