### PR TITLE
Release v0.16.4

### DIFF
--- a/.github/workflows/CompatCheck.yml
+++ b/.github/workflows/CompatCheck.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         downgrade_mode: ['deps']
         group: ${{ fromJSON(needs.setup-matrix.outputs.groups) }}
-        julia-version: ['1', '1.10']
+        julia-version: ['1.10']
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,9 @@ authors:
   given-names: "Jutho"
   orcid: "https://orcid.org/0000-0002-0858-291X"
 title: "TensorKit.jl"
-version: "0.16.3"
+version: "0.16.4"
 doi: "10.5281/zenodo.8421339"
-date-released: "2026-02-22"
+date-released: "2026-04-23"
 url: "https://github.com/QuantumKitHub/TensorKit.jl"
 preferred-citation:
   type: article

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorKit"
 uuid = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
-version = "0.16.3"
+version = "0.16.4"
 authors = ["Jutho Haegeman, Lukas Devos"]
 
 [deps]

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -18,22 +18,42 @@ When making changes to this project, please update the "Unreleased" section with
 
 When releasing a new version, move the "Unreleased" changes to a new version section with the release date.
 
-## [Unreleased](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.3...HEAD)
+## [Unreleased](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.4...HEAD)
 
 ### Added
 
-
 ### Changed
-
 
 ### Deprecated
 
-
 ### Removed
-
 
 ### Fixed
 
+### Performance
+
+## [0.16.4](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.3...v0.16.4) - 2026-04-23
+
+### Added
+
+- Basic tensor support for AMDGPU via a new extension ([#341](https://github.com/QuantumKitHub/TensorKit.jl/pull/341))
+- Define `spacetype` for `TruncationSpace` ([#403](https://github.com/QuantumKitHub/TensorKit.jl/pull/403))
+- Add square checks for `project_(anti)hermitian` and eigenvalue decompositions ([#408](https://github.com/QuantumKitHub/TensorKit.jl/pull/408))
+
+### Changed
+
+- Updated MatrixAlgebraKit dependency to v0.6.5 with corresponding API updates ([#390](https://github.com/QuantumKitHub/TensorKit.jl/pull/390))
+
+### Fixed
+
+- Fix ignored `adjoint` flag in `BraidingTensor` ([#392](https://github.com/QuantumKitHub/TensorKit.jl/pull/392))
+- Fix `MethodError` for certain tensor operations ([#406](https://github.com/QuantumKitHub/TensorKit.jl/pull/406))
+
+### Performance
+
+- Vectorize fusiontree manipulations ([#261](https://github.com/QuantumKitHub/TensorKit.jl/pull/261))
+- Avoid generic matmul fallback ([#378](https://github.com/QuantumKitHub/TensorKit.jl/pull/378))
+- Reduce cache footprint by decoupling degeneracy-dependent data ([#387](https://github.com/QuantumKitHub/TensorKit.jl/pull/387))
 
 ## [0.16.3](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.2...v0.16.3) - 2026-02-22
 

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -38,7 +38,6 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 - Basic tensor support for AMDGPU via a new extension ([#341](https://github.com/QuantumKitHub/TensorKit.jl/pull/341))
 - Define `spacetype` for `TruncationSpace` ([#403](https://github.com/QuantumKitHub/TensorKit.jl/pull/403))
-- Add square checks for `project_(anti)hermitian` and eigenvalue decompositions ([#408](https://github.com/QuantumKitHub/TensorKit.jl/pull/408))
 
 ### Changed
 
@@ -48,11 +47,12 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 - Fix ignored `adjoint` flag in `BraidingTensor` ([#392](https://github.com/QuantumKitHub/TensorKit.jl/pull/392))
 - Fix `MethodError` for certain tensor operations ([#406](https://github.com/QuantumKitHub/TensorKit.jl/pull/406))
+- Add square checks for `project_(anti)hermitian` and eigenvalue decompositions ([#408](https://github.com/QuantumKitHub/TensorKit.jl/pull/408))
 
 ### Performance
 
 - Vectorize fusiontree manipulations ([#261](https://github.com/QuantumKitHub/TensorKit.jl/pull/261))
-- Avoid generic matmul fallback ([#378](https://github.com/QuantumKitHub/TensorKit.jl/pull/378))
+- Avoid generic matmul fallback in transformation kernel ([#378](https://github.com/QuantumKitHub/TensorKit.jl/pull/378))
 - Reduce cache footprint by decoupling degeneracy-dependent data ([#387](https://github.com/QuantumKitHub/TensorKit.jl/pull/387))
 
 ## [0.16.3](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.2...v0.16.3) - 2026-02-22

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -36,7 +36,7 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 ### Added
 
-- Basic tensor support for AMDGPU via a new extension ([#341](https://github.com/QuantumKitHub/TensorKit.jl/pull/341))
+- Partial tensor support for AMDGPU via a new extension ([#341](https://github.com/QuantumKitHub/TensorKit.jl/pull/341))
 - Define `spacetype` for `TruncationSpace` ([#403](https://github.com/QuantumKitHub/TensorKit.jl/pull/403))
 
 ### Changed


### PR DESCRIPTION
## TensorKit.jl v0.16.4

Patch release with AMDGPU support, significant performance improvements to fusiontree manipulations, and several bug fixes.

### Highlights
- Partial tensor support for AMDGPU via a new extension ([#341](https://github.com/QuantumKitHub/TensorKit.jl/pull/341))
- Significant performance improvements: vectorized fusiontree manipulations ([#261](https://github.com/QuantumKitHub/TensorKit.jl/pull/261)), reduced cache footprint ([#387](https://github.com/QuantumKitHub/TensorKit.jl/pull/387)), avoid generic matmul fallback in transformation kernels ([#378](https://github.com/QuantumKitHub/TensorKit.jl/pull/378))
- Fixed ignored `adjoint` flag in `BraidingTensor` ([#392](https://github.com/QuantumKitHub/TensorKit.jl/pull/392))
- Added `spacetype` for `TruncationSpace` and square checks for `project_(anti)hermitian` / eigenvalue decompositions ([#403](https://github.com/QuantumKitHub/TensorKit.jl/pull/403), [#408](https://github.com/QuantumKitHub/TensorKit.jl/pull/408))

### Full Changelog
See [CHANGELOG](https://github.com/QuantumKitHub/TensorKit.jl/blob/main/docs/src/Changelog.md#0164---2026-04-23) for the complete list of changes.