### PR TITLE
Release v0.16.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,9 @@ authors:
   given-names: "Jutho"
   orcid: "https://orcid.org/0000-0002-0858-291X"
 title: "TensorKit.jl"
-version: "0.16.4"
+version: "0.16.5"
 doi: "10.5281/zenodo.8421339"
-date-released: "2026-04-23"
+date-released: "2026-04-30"
 url: "https://github.com/QuantumKitHub/TensorKit.jl"
 preferred-citation:
   type: article

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorKit"
 uuid = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
-version = "0.16.4"
+version = "0.16.5"
 authors = ["Jutho Haegeman, Lukas Devos"]
 
 [deps]

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -18,7 +18,7 @@ When making changes to this project, please update the "Unreleased" section with
 
 When releasing a new version, move the "Unreleased" changes to a new version section with the release date.
 
-## [Unreleased](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.4...HEAD)
+## [Unreleased](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.5...HEAD)
 
 ### Added
 
@@ -31,6 +31,17 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 ### Fixed
 
 ### Performance
+
+## [0.16.5](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.4...v0.16.5) - 2026-04-30
+
+### Added
+
+- Support for `DefaultAlgorithm` ([#422](https://github.com/QuantumKitHub/TensorKit.jl/pull/422), [#423](https://github.com/QuantumKitHub/TensorKit.jl/pull/423))
+
+### Fixed
+
+- Improve `checksquare` error message ([#417](https://github.com/QuantumKitHub/TensorKit.jl/pull/417))
+- Fix `BraidingTensor` `planarcontract!` ([#418](https://github.com/QuantumKitHub/TensorKit.jl/pull/418))
 
 ## [0.16.4](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.3...v0.16.4) - 2026-04-23
 


### PR DESCRIPTION
## TensorKit.jl v0.16.5

Patch release backporting fixes and a small feature from the v0.17 development line.

### Highlights
- Support for `DefaultAlgorithm` (#422, #423)
- Fix `BraidingTensor` `planarcontract!` (#418)
- Improve `checksquare` error message (#417)

### Full Changelog
See [CHANGELOG](https://github.com/QuantumKitHub/TensorKit.jl/blob/main/docs/src/Changelog.md#0165---2026-04-30) for the complete list of changes.