### PR TITLE
Fix for SUNRepresentations type parameter change

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,6 +16,6 @@ TensorKit = {path = ".."}
 [compat]
 Documenter = "1"
 DocumenterInterLinks = "1"
-SUNRepresentations = "0.3"
+SUNRepresentations = "0.4"
 Test = "1"
 WignerSymbols = "1,2"

--- a/docs/src/appendix/symmetric_tutorial.md
+++ b/docs/src/appendix/symmetric_tutorial.md
@@ -960,7 +960,6 @@ The eigenvalue of the quadratic Casimir for a given irrep is given by [Freudenth
 \Omega(D(p,q)) = \frac{1}{3} (p^2 + q^2 + 3p + 3q + pq).
 ```
 This can be computed using SUNRepresentations.jl's `casimir` method, where `casimir(2, l)` returns the quadratic Casimir for irrep `l`.
-```
 If we use the adjoint representation of ``\mathsf{SU}_3`` as physical space, the Heisenberg exchange interaction can then be constructed as
 ```@example symmetric_tutorial
 V = Vect[SU3Irrep](SU3Irrep("8") => 1)

--- a/docs/src/appendix/symmetric_tutorial.md
+++ b/docs/src/appendix/symmetric_tutorial.md
@@ -959,12 +959,7 @@ The eigenvalue of the quadratic Casimir for a given irrep is given by [Freudenth
 ```math
 \Omega(D(p,q)) = \frac{1}{3} (p^2 + q^2 + 3p + 3q + pq).
 ```
-Using SUNRepresentations.jl, we can compute the Casimir as
-```@example symmetric_tutorial
-function casimir(l::SU3Irrep)
-    p, q = dynkin_label(l)
-    return (p^2 + q^2 + 3 * p + 3 * q + p * q) / 3
-end
+This can be computed using SUNRepresentations.jl's `casimir` method, where `casimir(2, l)` returns the quadratic Casimir for irrep `l`.
 ```
 If we use the adjoint representation of ``\mathsf{SU}_3`` as physical space, the Heisenberg exchange interaction can then be constructed as
 ```@example symmetric_tutorial
@@ -974,7 +969,7 @@ for (s, f) in fusiontrees(TT)
     l3 = f.uncoupled[1]
     l4 = f.uncoupled[2]
     k = f.coupled
-    TT[s, f] .= (casimir(k) - casimir(l3) - casimir(l4)) / 2
+    TT[s, f] .= (casimir(2, k) - casimir(2, l3) - casimir(2, l4)) / 2
 end
 subblocks(TT)
 ```

--- a/docs/src/appendix/symmetric_tutorial.md
+++ b/docs/src/appendix/symmetric_tutorial.md
@@ -968,7 +968,7 @@ end
 ```
 If we use the adjoint representation of ``\mathsf{SU}_3`` as physical space, the Heisenberg exchange interaction can then be constructed as
 ```@example symmetric_tutorial
-V = Vect[SUNIrrep{3}](SU3Irrep("8") => 1)
+V = Vect[SU3Irrep](SU3Irrep("8") => 1)
 TT = zeros(ComplexF64, V ⊗ V ← V ⊗ V)
 for (s, f) in fusiontrees(TT)
     l3 = f.uncoupled[1]


### PR DESCRIPTION
Small fix in the symmetric tensor tutorial for SUNRepresentations v0.4, where `SUNIrrep{3}` has become an abstract type. It anyway made no sense to mix `SU3Irrep` and `SUNIrrep{3}` in the same line, looks needlessly confusing.

If we want, I can also bump the SUNRepresentations compat entry to v0.4 in the docs project, so we can use `SUNRepresentations.casimir` instead of having to define our own `casimir` method. It's quite pedagogical the way it is so I didn't do this right away, but if this would be better I'll change it.