### PR TITLE
`isdual` for AbstractTensorMaps

### DIFF
--- a/src/tensors/abstracttensor.jl
+++ b/src/tensors/abstracttensor.jl
@@ -308,6 +308,15 @@ function adjointtensorindices(t, p::Index2Tuple)
     return (adjointtensorindices(t, p[1]), adjointtensorindices(t, p[2]))
 end
 
+"""
+    isdual(x::AbstractTensorMap) -> Vector{Bool}
+
+Returns a Boolean vector indicating which spaces of `x` are dual spaces.
+"""
+function isdual(x::AbstractTensorMap)
+    return [isdual(space(x, i)) for i in 1:numind(x)]
+end
+
 # tensor characteristics: work on instances and pass to type
 #------------------------------------------------------------
 InnerProductStyle(t::AbstractTensorMap) = InnerProductStyle(typeof(t))

--- a/test/tensors/construction.jl
+++ b/test/tensors/construction.jl
@@ -24,6 +24,7 @@ for V in spacelist
                 @test space(t) == (W ← one(W))
                 @test domain(t) == one(W)
                 @test typeof(t) == TensorMap{T, spacetype(t), 5, 0, Vector{T}}
+                @constinferred isdual(t)
                 # Array type input
                 t = @constinferred zeros(Vector{T}, W)
                 @test @constinferred(hash(t)) == hash(deepcopy(t))


### PR DESCRIPTION
This PR adds a utility function `isdual(x::AbstractTensorMap)` that returns a Boolean vector indicating which spaces of a tensor map are dual spaces. For example:
```julia
x = randn(ℂ^2 ⊗ (ℂ^3)' ← (ℂ^1)' ⊗ ℂ^4)
isdual(x) # returns [0, 1, 0, 1] as a Boolean vector
```
It is mainly used to assert that arrows in a network are preserved, which I frequently need to do.

The name of the function can be changed if you feel that `isdual` must return a single `Bool`. I don't know how to meaningfully test it, either.