### PR TITLE
Return a tuple when broadcasting over ProductSpace

### DIFF
--- a/src/spaces/productspace.jl
+++ b/src/spaces/productspace.jl
@@ -341,6 +341,8 @@ end
 Base.length(P::ProductSpace) = length(P.spaces)
 Base.getindex(P::ProductSpace, n::Integer) = P.spaces[n]
 
+Base.Broadcast.broadcastable(P::ProductSpace) = P.spaces
+
 Base.iterate(P::ProductSpace, args...) = Base.iterate(P.spaces, args...)
 Base.indexed_iterate(P::ProductSpace, args...) = Base.indexed_iterate(P.spaces, args...)
 

--- a/test/symmetries/spaces.jl
+++ b/test/symmetries/spaces.jl
@@ -295,6 +295,7 @@ end
     @test @constinferred(hash(P)) == hash(deepcopy(P)) != hash(P')
     @test P == deepcopy(P)
     @test P == typeof(P)(P...)
+    @test map(identity, P) == identity.(P)
     @constinferred (x -> tuple(x...))(P)
     @test @constinferred(dual(P)) == P'
     @test @constinferred(field(P)) == ℂ


### PR DESCRIPTION
With this PR, `f.(::ProductSpace)` and `map(f, ::ProductSpace)` will be the same, both returning a tuple.

First raised in https://github.com/QuantumKitHub/TensorKit.jl/pull/429#issuecomment-4438651843.