### PR TITLE
Fix `isapprox` for TensorMaps with different spaces

### DIFF
--- a/src/tensors/abstracttensor.jl
+++ b/src/tensors/abstracttensor.jl
@@ -683,6 +683,7 @@ function Base.isapprox(
         t1::AbstractTensorMap, t2::AbstractTensorMap;
         atol::Real = 0, rtol::Real = Base.rtoldefault(scalartype(t1), scalartype(t2), atol)
     )
+    (codomain(t1) == codomain(t2) && domain(t1) == domain(t2)) || return false
     d = norm(t1 - t2)
     if isfinite(d)
         return d <= max(atol, rtol * max(norm(t1), norm(t2)))


### PR DESCRIPTION
This PR improves `isapprox` for TensorMaps: when two TensorMaps have different spaces, `isapprox` should directly return `false`. Previously such a check is missing and a `SpaceMismatch` error will be raised.