### PR TITLE
Fix foldright cache miss dual flag

### DIFF
--- a/src/fusiontrees/duality_manipulations.jl
+++ b/src/fusiontrees/duality_manipulations.jl
@@ -272,7 +272,7 @@ function foldright(src::FusionTreeBlock)
                 Asymbol(a, b, c)
             end
             f₂′s, coeffs₂ = get!(cache₂, (b, f₂)) do
-                multi_Fmove_inv(dual(a), b, f₂)
+                multi_Fmove_inv(dual(a), b, f₂, !isduala)
             end
             coeff₀ = sqrtdim(c) * invsqrtdim(b)
             for (f₂′, coeff₂) in zip(f₂′s, coeffs₂)


### PR DESCRIPTION
This fixes the cache miss path in `foldright(::FusionTreeBlock)` by passing the same `!isduala` argument to `multi_Fmove_inv` as the cache initialization path.

Without this argument, the miss path can construct intermediate trees with `isdual` metadata inconsistent with the destination block. The current matrix result is typically unaffected because `treeindex_data` ignores block-level `isdual`, but the cached tree metadata is inconsistent and differs from the `foldleft` implementation.

Local checks:
- `git diff --check`
- focused Julia check covering `foldright`/`foldleft` round trip for SU2Irrep, FibonacciAnyon, and IsingAnyon