### PR TITLE
Bypass some overhead in TensorMap constructor, bypass overhead in `sectorequal`/`sectorhash` for trivial symmetry

### DIFF
--- a/src/spaces/cartesianspace.jl
+++ b/src/spaces/cartesianspace.jl
@@ -74,5 +74,5 @@ sectortype(::Type{CartesianSpace}) = Trivial
 
 Base.show(io::IO, V::CartesianSpace) = print(io, "ℝ^$(V.d)")
 
-sectorhash(::CartesianSpace, h::UInt) = h
-sectorequal(::CartesianSpace, ::CartesianSpace) = true
+sectorhash(V::CartesianSpace, h::UInt) = hash(dim(V) == 0, h)
+sectorequal(V₁::CartesianSpace, V₂::CartesianSpace) = iszero(dim(V₁)) == iszero(dim(V₂))

--- a/src/spaces/cartesianspace.jl
+++ b/src/spaces/cartesianspace.jl
@@ -73,3 +73,6 @@ sectors(V::CartesianSpace) = OneOrNoneIterator(dim(V) != 0, Trivial())
 sectortype(::Type{CartesianSpace}) = Trivial
 
 Base.show(io::IO, V::CartesianSpace) = print(io, "ℝ^$(V.d)")
+
+sectorhash(::CartesianSpace, h::UInt) = h
+sectorequal(::CartesianSpace, ::CartesianSpace) = true

--- a/src/spaces/complexspace.jl
+++ b/src/spaces/complexspace.jl
@@ -83,5 +83,9 @@ sectortype(::Type{ComplexSpace}) = Trivial
 
 Base.show(io::IO, V::ComplexSpace) = print(io, isdual(V) ? "(ℂ^$(V.d))'" : "ℂ^$(V.d)")
 
-sectorhash(V::ComplexSpace, h::UInt) = hash(isdual(V), h)
-sectorequal(V₁::ComplexSpace, V₂::ComplexSpace) = isdual(V₁) == isdual(V₂)
+function sectorhash(V::ComplexSpace, h::UInt)
+    return hash(dim(V) == 0, hash(isdual(V), h))
+end
+function sectorequal(V₁::ComplexSpace, V₂::ComplexSpace)
+    return isdual(V₁) == isdual(V₂) && iszero(dim(V₁)) == iszero(dim(V₂))
+end

--- a/src/spaces/complexspace.jl
+++ b/src/spaces/complexspace.jl
@@ -82,3 +82,6 @@ sectors(V::ComplexSpace) = OneOrNoneIterator(dim(V) != 0, Trivial())
 sectortype(::Type{ComplexSpace}) = Trivial
 
 Base.show(io::IO, V::ComplexSpace) = print(io, isdual(V) ? "(ℂ^$(V.d))'" : "ℂ^$(V.d)")
+
+sectorhash(V::ComplexSpace, h::UInt) = hash(isdual(V), h)
+sectorequal(V₁::ComplexSpace, V₂::ComplexSpace) = isdual(V₁) == isdual(V₂)

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -10,6 +10,13 @@ a tensor category), where the data is stored in a dense vector.
 struct TensorMap{T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}} <: AbstractTensorMap{T, S, N₁, N₂}
     data::A
     space::TensorMapSpace{S, N₁, N₂}
+
+    # explicit inner constructor to prevent auto-generating TensorMap(data, space)
+    function TensorMap{T, S, N₁, N₂, A}(
+            data::A, space::TensorMapSpace{S, N₁, N₂}
+        ) where {T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}}
+        return new{T, S, N₁, N₂, A}(data, space)
+    end
 end
 
 """

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -10,30 +10,7 @@ a tensor category), where the data is stored in a dense vector.
 struct TensorMap{T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}} <: AbstractTensorMap{T, S, N₁, N₂}
     data::A
     space::TensorMapSpace{S, N₁, N₂}
-
-    # uninitialized constructors
-    function TensorMap{T, S, N₁, N₂, A}(
-            ::UndefInitializer, space::TensorMapSpace{S, N₁, N₂}
-        ) where {T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}}
-        data = A(undef, dim(space))
-        if !isbitstype(T)
-            zerovector!(data)
-        end
-        return TensorMap{T, S, N₁, N₂, A}(data, space)
-    end
-    # constructors from data
-    function TensorMap{T, S, N₁, N₂, A}(
-            data::A, space::TensorMapSpace{S, N₁, N₂}
-        ) where {T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}}
-        T ⊆ field(S) || @warn("scalartype(data) = $T ⊈ $(field(S)))", maxlog = 1)
-        I = sectortype(S)
-        T <: Real && !(sectorscalartype(I) <: Real) &&
-            @warn("Tensors with real data might be incompatible with sector type $I", maxlog = 1)
-        length(data) == dim(space) || throw(DimensionMismatch(lazy"length of data ($(length(data))) does not match dimension of space ($(dim(space)))"))
-        return new{T, S, N₁, N₂, A}(data, space)
-    end
 end
-TensorMap{T, S, N₁, N₂, A}(t::TensorMap{T, S, N₁, N₂}) where {T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}} = TensorMap(A(t.data), space(t))
 
 """
     Tensor{T, S, N, A<:DenseVector{T}} = TensorMap{T, S, N, 0, A}
@@ -46,9 +23,25 @@ i.e. a tensor map with only a non-trivial output space.
 """
 const Tensor{T, S, N, A} = TensorMap{T, S, N, 0, A}
 
+# Utility functions:
+# ------------------
 function tensormaptype(::Type{S}, N₁, N₂, ::Type{TorA}) where {S <: IndexSpace, TorA}
     A = similarstoragetype(TorA)
     return TensorMap{scalartype(A), S, N₁, N₂, A}
+end
+
+function _warn_tensormap_compatibility(T, S)
+    T ⊆ field(S) || @warn("scalartype(data) = $T ⊈ $(field(S)))", maxlog = 1)
+    I = sectortype(S)
+    T <: Real && !(sectorscalartype(I) <: Real) &&
+        @warn("Tensors with real data might be incompatible with sector type $I", maxlog = 1)
+    return nothing
+end
+
+function _check_tensormap_length(data, V)
+    d = dim(V)
+    length(data) == d || throw(DimensionMismatch(lazy"length of data ($(length(data))) does not match dimension of space ($d)"))
+    return nothing
 end
 
 # Basic methods for characterising a tensor:
@@ -66,6 +59,8 @@ dim(t::TensorMap) = length(t.data)
 
 # General TensorMap constructors
 # ==============================
+TensorMap{T, S, N₁, N₂, A}(t::TensorMap{T, S, N₁, N₂}) where {T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}} =
+    TensorMap{T, S, N₁, N₂, A}(A(t.data), space(t))
 
 # INTERNAL: utility type alias that makes constructors also work for type aliases that specify
 # different storage types. (i.e. CuTensorMap = TensorMapWithStorage{T, CuVector{T}, ...})
@@ -89,6 +84,14 @@ TensorMap{T}(::UndefInitializer, V::TensorMapSpace) where {T} =
 TensorMap{T}(::UndefInitializer, codomain::TensorSpace, domain::TensorSpace) where {T} =
     TensorMap{T}(undef, codomain ← domain)
 Tensor{T}(::UndefInitializer, V::TensorSpace) where {T} = TensorMap{T}(undef, V ← one(V))
+function TensorMap{T, S, N₁, N₂, A}(
+        ::UndefInitializer, space::TensorMapSpace{S, N₁, N₂}
+    ) where {T, S <: IndexSpace, N₁, N₂, A <: DenseVector{T}}
+    _warn_tensormap_compatibility(T, S)
+    data = A(undef, dim(space))
+    isbitstype(T) || zerovector!(data) # ensure initialized entries
+    return TensorMap{T, S, N₁, N₂, A}(data, space)
+end
 
 """
     TensorMapWithStorage{T, A}(undef, codomain, domain) where {T, A}
@@ -122,10 +125,13 @@ TensorMap(t::TensorMap) = copy(t)
 Construct a `TensorMap` from the given raw data.
 This constructor takes ownership of the provided vector, and will not make an independent copy.
 """
-TensorMap{T}(data::DenseVector{T}, V::TensorMapSpace) where {T} =
-    tensormaptype(spacetype(V), numout(V), numin(V), typeof(data))(data, V)
 TensorMap{T}(data::DenseVector{T}, codomain::TensorSpace, domain::TensorSpace) where {T} =
     TensorMap{T}(data, codomain ← domain)
+function TensorMap{T}(data::DenseVector{T}, V::TensorMapSpace) where {T}
+    _warn_tensormap_compatibility(T, spacetype(V))
+    _check_tensormap_length(data, V)
+    return tensormaptype(spacetype(V), numout(V), numin(V), typeof(data))(data, V)
+end
 
 """
     TensorMapWithStorage{T, A}(data::A, codomain, domain) where {T, A<:DenseVector{T}}
@@ -136,6 +142,8 @@ Construct a `TensorMap` from the given raw data.
 This constructor takes ownership of the provided vector, and will not make an independent copy.
 """
 function TensorMapWithStorage{T, A}(data::A, V::TensorMapSpace) where {T, A}
+    _warn_tensormap_compatibility(T, spacetype(V))
+    _check_tensormap_length(data, V)
     return tensormaptype(spacetype(V), numout(V), numin(V), typeof(data))(data, V)
 end
 TensorMapWithStorage{T, A}(data::A, codomain::TensorSpace, domain::TensorSpace) where {T, A} =
@@ -213,13 +221,17 @@ end
 function TensorMapWithStorage{T, A}(
         data::AbstractArray, V::TensorMapSpace; tol = sqrt(eps(real(float(eltype(data)))))
     ) where {T, A}
+    _warn_tensormap_compatibility(T, spacetype(V))
+
     # refer to specific raw data constructors if input is a vector of the correct length
     ndims(data) == 1 && length(data) == dim(V) &&
         return tensormaptype(spacetype(V), numout(V), numin(V), A)(data, V)
 
     # special case trivial: refer to same method, but now with vector argument
-    sectortype(V) === Trivial &&
+    if sectortype(V) === Trivial
+        _check_tensormap_length(data, V)
         return tensormaptype(spacetype(V), numout(V), numin(V), A)(reshape(data, length(data)), V)
+    end
 
     return project_symmetric_and_check(T, A, data, V; tol)
 end


### PR DESCRIPTION
As discussed with @Jutho and @kshyatt before, this PR consists of two changes:

The first (set) is:
- The inner constructors for `TensorMap` are now no longer doing the checks, bypassing a small amount of overhead for looking up some of the cached data, as well as a small amount of overhead for the warnings with `maxlog = 1`.
- The outer constructors now have these warnings/checks to keep the external behavior more or less the same

The second is:
- `sectorequal` and `sectorhash` can be specialized for `Trivial` symmetry type, as brought up in #475.

Note that this is only a partial fix for #475, and to thoroughly fix some of this we would probably rather try to avoid caching the symmetry structure, which requires slightly more plumbing which I would like to hold off on for now, if this turns out to not be required it's a bunch of specialized code to maintain and check.