### PR TITLE
Update benchmark suite to current TensorKit API

### DIFF
--- a/benchmark/TensorKitBenchmarks/linalg/LinalgBenchmarks.jl
+++ b/benchmark/TensorKitBenchmarks/linalg/LinalgBenchmarks.jl
@@ -67,7 +67,7 @@ function benchmark_svd!(bench; sigmas = nothing, T = "Float64", I = "Trivial", d
     I_ = parse_type(I)
     Vs = generate_space.(I_, dims, sigmas)
     init() = init_svd_tensor(T_, Vs)
-    bench[T, I, dims, sigmas] = @benchmarkable tsvd!(A) setup = (A = $init())
+    bench[T, I, dims, sigmas] = @benchmarkable svd_compact!(A) setup = (A = $init())
     return nothing
 end
 

--- a/benchmark/TensorKitBenchmarks/tensornetworks/TensorNetworkBenchmarks.jl
+++ b/benchmark/TensorKitBenchmarks/tensornetworks/TensorNetworkBenchmarks.jl
@@ -13,10 +13,10 @@ const all_parameters = TOML.parsefile(joinpath(@__DIR__, "benchparams.toml"))
 # mpo contraction
 # ---------------
 function init_mpo_tensors(T, (Vmps, Vmpo, Vphys))
-    A = Tensor(randn, T, Vmps ⊗ Vphys ⊗ Vmps')
-    M = Tensor(randn, T, Vmpo ⊗ Vphys ⊗ Vphys' ⊗ Vmpo')
-    FL = Tensor(randn, T, Vmps ⊗ Vmpo' ⊗ Vmps')
-    FR = Tensor(randn, T, Vmps ⊗ Vmpo ⊗ Vmps')
+    A = randn(T, Vmps ⊗ Vphys ⊗ Vmps')
+    M = randn(T, Vmpo ⊗ Vphys ⊗ Vphys' ⊗ Vmpo')
+    FL = randn(T, Vmps ⊗ Vmpo' ⊗ Vmps')
+    FR = randn(T, Vmps ⊗ Vmpo ⊗ Vmps')
     return A, M, FL, FR
 end
 
@@ -53,12 +53,12 @@ end
 # pepo contraction
 # ----------------
 function init_pepo_tensors(T, (Vpeps, Vpepo, Vphys, Venv))
-    A = Tensor(randn, T, Vpeps ⊗ Vpeps ⊗ Vphys ⊗ Vpeps' ⊗ Vpeps')
-    P = Tensor(randn, T, Vpepo ⊗ Vpepo ⊗ Vphys ⊗ Vphys' ⊗ Vpepo' ⊗ Vpepo')
-    FL = Tensor(randn, T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
-    FD = Tensor(randn, T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
-    FR = Tensor(randn, T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
-    FU = Tensor(randn, T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
+    A = randn(T, Vpeps ⊗ Vpeps ⊗ Vphys ⊗ Vpeps' ⊗ Vpeps')
+    P = randn(T, Vpepo ⊗ Vpepo ⊗ Vphys ⊗ Vphys' ⊗ Vpepo' ⊗ Vpepo')
+    FL = randn(T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
+    FD = randn(T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
+    FR = randn(T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
+    FU = randn(T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
     return A, P, FL, FD, FR, FU
 end
 
@@ -97,10 +97,10 @@ end
 # mera contraction
 # ----------------
 function init_mera_tensors(T, V)
-    u = Tensor(randn, T, V ⊗ V ⊗ V' ⊗ V')
-    w = Tensor(randn, T, V ⊗ V ⊗ V')
-    ρ = Tensor(randn, T, V ⊗ V ⊗ V ⊗ V' ⊗ V' ⊗ V')
-    h = Tensor(randn, T, V ⊗ V ⊗ V ⊗ V' ⊗ V' ⊗ V')
+    u = randn(T, V ⊗ V ⊗ V' ⊗ V')
+    w = randn(T, V ⊗ V ⊗ V')
+    ρ = randn(T, V ⊗ V ⊗ V ⊗ V' ⊗ V' ⊗ V')
+    h = randn(T, V ⊗ V ⊗ V ⊗ V' ⊗ V' ⊗ V')
     return u, w, ρ, h
 end
 

--- a/benchmark/comparisons/run_tensorkit.jl
+++ b/benchmark/comparisons/run_tensorkit.jl
@@ -4,8 +4,6 @@ include("tensorkit_timers.jl")
 using LinearAlgebra: LinearAlgebra
 LinearAlgebra.BLAS.set_num_threads(1)
 
-using TensorOperations: TensorOperations
-TensorOperations.enable_cache(; maxrelsize = 0.7)
 using TensorKit: TensorKit
 using TensorKit: ℂ, Z2Space, U1Space
 using DelimitedFiles
@@ -32,7 +30,6 @@ for i in 1:N
     times, times_gc = mpo_timer(; outer = K)
     mpo_triv_times[:, i] = times
     mpo_triv_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -60,7 +57,6 @@ for i in 1:N
     times, times_gc = mpo_timer(; outer = K)
     mpo_z2_times[:, i] = times
     mpo_z2_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -88,7 +84,6 @@ for i in 1:N
     times, times_gc = mpo_timer(; outer = K)
     mpo_u1_times[:, i] = times
     mpo_u1_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -120,7 +115,6 @@ for i in 1:N
     times, times_gc = pepo_timer(; outer = K)
     pepo_triv_times[:, i] = times
     pepo_triv_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -150,7 +144,6 @@ for i in 1:N
     times, times_gc = pepo_timer(; outer = K)
     pepo_z2_times[:, i] = times
     pepo_z2_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -180,7 +173,6 @@ for i in 1:N
     times, times_gc = pepo_timer(; outer = K)
     pepo_u1_times[:, i] = times
     pepo_u1_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -207,7 +199,6 @@ for i in 1:N
 
     mera_triv_times[:, i] = times
     mera_triv_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -232,7 +223,6 @@ for i in 1:N
 
     mera_z2_times[:, i] = times
     mera_z2_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 
@@ -257,7 +247,6 @@ for i in 1:N
 
     mera_u1_times[:, i] = times
     mera_u1_times_gc[:, i] = times_gc
-    empty!(TensorOperations.cache)
 
     tavg = sum(times) / K
 

--- a/benchmark/comparisons/tensorkit_timers.jl
+++ b/benchmark/comparisons/tensorkit_timers.jl
@@ -4,10 +4,10 @@ module TensorKitTimers
     using ..Timers: Timers
 
     function mpo_timer(f = randn, T = Float64; Vmpo, Vmps, Vphys)
-        A = Tensor(f, T, Vmps ⊗ Vphys ⊗ Vmps')
-        M = Tensor(f, T, Vmpo ⊗ Vphys ⊗ Vphys' ⊗ Vmpo')
-        FL = Tensor(f, T, Vmps ⊗ Vmpo' ⊗ Vmps')
-        FR = Tensor(f, T, Vmps ⊗ Vmpo ⊗ Vmps')
+        A = f(T, Vmps ⊗ Vphys ⊗ Vmps')
+        M = f(T, Vmpo ⊗ Vphys ⊗ Vphys' ⊗ Vmpo')
+        FL = f(T, Vmps ⊗ Vmpo' ⊗ Vmps')
+        FR = f(T, Vmps ⊗ Vmpo ⊗ Vmps')
 
         return Timers.Timer(A, M, FL, FR) do A, M, FL, FR
             @tensor C = FL[4, 2, 1] * A[1, 3, 6] * M[2, 5, 3, 7] * conj(A[4, 5, 8]) *
@@ -17,12 +17,12 @@ module TensorKitTimers
     end
 
     function pepo_timer(f = randn, T = Float64; Vpepo, Vpeps, Venv, Vphys)
-        A = Tensor(f, T, Vpeps ⊗ Vpeps ⊗ Vphys ⊗ Vpeps' ⊗ Vpeps')
-        P = Tensor(f, T, Vpepo ⊗ Vpepo ⊗ Vphys ⊗ Vphys' ⊗ Vpepo' ⊗ Vpepo')
-        FL = Tensor(f, T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
-        FD = Tensor(f, T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
-        FR = Tensor(f, T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
-        FU = Tensor(f, T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
+        A = f(T, Vpeps ⊗ Vpeps ⊗ Vphys ⊗ Vpeps' ⊗ Vpeps')
+        P = f(T, Vpepo ⊗ Vpepo ⊗ Vphys ⊗ Vphys' ⊗ Vpepo' ⊗ Vpepo')
+        FL = f(T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
+        FD = f(T, Venv ⊗ Vpeps ⊗ Vpepo' ⊗ Vpeps' ⊗ Venv')
+        FR = f(T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
+        FU = f(T, Venv ⊗ Vpeps ⊗ Vpepo ⊗ Vpeps' ⊗ Venv')
         return Timers.Timer(A, P, FL, FD, FR, FU) do A, P, FL, FD, FR, FU
             @tensor C = FL[18, 7, 4, 2, 1] * FU[1, 3, 6, 9, 10] *
                 A[2, 17, 5, 3, 11] * P[4, 16, 8, 5, 6, 12] * conj(A[7, 15, 8, 9, 13]) *
@@ -32,10 +32,10 @@ module TensorKitTimers
     end
 
     function mera_timer(f = randn, T = Float64; Vmera)
-        u = Tensor(f, T, Vmera ⊗ Vmera ⊗ Vmera' ⊗ Vmera')
-        w = Tensor(f, T, Vmera ⊗ Vmera ⊗ Vmera')
-        ρ = Tensor(f, T, Vmera ⊗ Vmera ⊗ Vmera ⊗ Vmera' ⊗ Vmera' ⊗ Vmera')
-        h = Tensor(f, T, Vmera ⊗ Vmera ⊗ Vmera ⊗ Vmera' ⊗ Vmera' ⊗ Vmera')
+        u = f(T, Vmera ⊗ Vmera ⊗ Vmera' ⊗ Vmera')
+        w = f(T, Vmera ⊗ Vmera ⊗ Vmera')
+        ρ = f(T, Vmera ⊗ Vmera ⊗ Vmera ⊗ Vmera' ⊗ Vmera' ⊗ Vmera')
+        h = f(T, Vmera ⊗ Vmera ⊗ Vmera ⊗ Vmera' ⊗ Vmera' ⊗ Vmera')
         return Timers.Timer(u, w, ρ, h) do u, w, ρ, h
             @tensor C = (
                 (


### PR DESCRIPTION
The benchmark suite was still written against the pre-0.13 API and no longer loads with TensorKit 0.17. This updates it:

- `Tensor(randn, T, space)` → `randn(T, space)` in `TensorNetworkBenchmarks` and `comparisons/tensorkit_timers.jl` (the old function-first constructors were removed)
- `tsvd!` → `svd_compact!` in `LinalgBenchmarks` (factorizations now go through MatrixAlgebraKit)
- Removed `TensorOperations.enable_cache`/`empty!(TensorOperations.cache)` from `comparisons/run_tensorkit.jl` (the global cache API no longer exists in TensorOperations)

Verified by loading the full `SUITE` and running one benchmark from every group (`linalg/mul`, `linalg/svd`, `indexmanipulations/permute`, `tensornetworks/{mpo,pepo,mera}`) against the current `main`, plus exercising all three comparison timers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)