### PR TITLE
Release v0.17.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,9 @@ authors:
   given-names: "Jutho"
   orcid: "https://orcid.org/0000-0002-0858-291X"
 title: "TensorKit.jl"
-version: "0.17.0"
+version: "0.17.1"
 doi: "10.5281/zenodo.8421339"
-date-released: "2026-06-03"
+date-released: "2026-07-13"
 url: "https://github.com/QuantumKitHub/TensorKit.jl"
 preferred-citation:
   type: article

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorKit"
 uuid = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Jutho Haegeman, Lukas Devos"]
 
 [workspace]

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -38,6 +38,7 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 - Enzyme AD support: forward and reverse rules (with tests) for TensorOperations contractions, index manipulations, linear algebra, and VectorInterface operations ([#436](https://github.com/QuantumKitHub/TensorKit.jl/pull/436), [#437](https://github.com/QuantumKitHub/TensorKit.jl/pull/437), [#440](https://github.com/QuantumKitHub/TensorKit.jl/pull/440), [#449](https://github.com/QuantumKitHub/TensorKit.jl/pull/449), [#451](https://github.com/QuantumKitHub/TensorKit.jl/pull/451), [#466](https://github.com/QuantumKitHub/TensorKit.jl/pull/466))
 - `exponential` and `exponential!` for the matrix exponential of tensors ([#465](https://github.com/QuantumKitHub/TensorKit.jl/pull/465))
+- Docstrings for `catdomain` and `catcodomain` ([#485](https://github.com/QuantumKitHub/TensorKit.jl/pull/485))
 
 ### Changed
 

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -36,14 +36,14 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 ### Added
 
-- Enzyme AD support: forward and reverse rules (with tests) for TensorOperations contractions, index manipulations, linear algebra, and VectorInterface operations ([#436](https://github.com/QuantumKitHub/TensorKit.jl/pull/436), [#437](https://github.com/QuantumKitHub/TensorKit.jl/pull/437), [#440](https://github.com/QuantumKitHub/TensorKit.jl/pull/440), [#449](https://github.com/QuantumKitHub/TensorKit.jl/pull/449), [#451](https://github.com/QuantumKitHub/TensorKit.jl/pull/451), [#466](https://github.com/QuantumKitHub/TensorKit.jl/pull/466))
+- Enzyme AD support: forward and reverse rules (with tests) for TensorOperations contractions, linear algebra, and VectorInterface operations, and reverse rules for index manipulations ([#436](https://github.com/QuantumKitHub/TensorKit.jl/pull/436), [#437](https://github.com/QuantumKitHub/TensorKit.jl/pull/437), [#440](https://github.com/QuantumKitHub/TensorKit.jl/pull/440), [#449](https://github.com/QuantumKitHub/TensorKit.jl/pull/449), [#451](https://github.com/QuantumKitHub/TensorKit.jl/pull/451), [#466](https://github.com/QuantumKitHub/TensorKit.jl/pull/466))
 - `exponential` and `exponential!` for the matrix exponential of tensors ([#465](https://github.com/QuantumKitHub/TensorKit.jl/pull/465))
 - Docstrings for `catdomain` and `catcodomain` ([#485](https://github.com/QuantumKitHub/TensorKit.jl/pull/485))
 
 ### Changed
 
 - Consolidated duplicated GPU logic into a new GPUArrays extension ([#460](https://github.com/QuantumKitHub/TensorKit.jl/pull/460))
-- Removed explicit dependence on cuTENSOR for the CUDA extension ([#455](https://github.com/QuantumKitHub/TensorKit.jl/pull/455))
+- Removed explicit dependence on cuTENSOR for the CUDA extension; importing `cuTENSOR` is still recommended for best performance, as it enables the corresponding TensorOperations extension ([#455](https://github.com/QuantumKitHub/TensorKit.jl/pull/455))
 - Improved `DimensionMismatch` error message in the `TensorMap` constructor ([#456](https://github.com/QuantumKitHub/TensorKit.jl/pull/456))
 
 ### Fixed

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -18,7 +18,7 @@ When making changes to this project, please update the "Unreleased" section with
 
 When releasing a new version, move the "Unreleased" changes to a new version section with the release date.
 
-## [Unreleased](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.17.0...HEAD)
+## [Unreleased](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.17.1...HEAD)
 
 ### Added
 
@@ -31,6 +31,30 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 ### Fixed
 
 ### Performance
+
+## [0.17.1](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.17.0...v0.17.1) - 2026-07-13
+
+### Added
+
+- Enzyme AD support: forward and reverse rules (with tests) for TensorOperations contractions, index manipulations, linear algebra, and VectorInterface operations ([#436](https://github.com/QuantumKitHub/TensorKit.jl/pull/436), [#437](https://github.com/QuantumKitHub/TensorKit.jl/pull/437), [#440](https://github.com/QuantumKitHub/TensorKit.jl/pull/440), [#449](https://github.com/QuantumKitHub/TensorKit.jl/pull/449), [#451](https://github.com/QuantumKitHub/TensorKit.jl/pull/451), [#466](https://github.com/QuantumKitHub/TensorKit.jl/pull/466))
+- `exponential` and `exponential!` for the matrix exponential of tensors ([#465](https://github.com/QuantumKitHub/TensorKit.jl/pull/465))
+
+### Changed
+
+- Consolidated duplicated GPU logic into a new GPUArrays extension ([#460](https://github.com/QuantumKitHub/TensorKit.jl/pull/460))
+- Removed explicit dependence on cuTENSOR for the CUDA extension ([#455](https://github.com/QuantumKitHub/TensorKit.jl/pull/455))
+- Improved `DimensionMismatch` error message in the `TensorMap` constructor ([#456](https://github.com/QuantumKitHub/TensorKit.jl/pull/456))
+
+### Fixed
+
+- Added missing zero-derivatives and an in-place rrule test for `svd_trunc` ([#448](https://github.com/QuantumKitHub/TensorKit.jl/pull/448))
+
+### Performance
+
+- Reduced overhead in the `TensorMap` constructor and in `sectorequal`/`sectorhash` for trivial symmetries ([#476](https://github.com/QuantumKitHub/TensorKit.jl/pull/476))
+- Further trivial-symmetry improvements and reduced respecialization for `contract!` ([#479](https://github.com/QuantumKitHub/TensorKit.jl/pull/479))
+- Fast path for trivial tensors into the TensorOperations machinery ([#463](https://github.com/QuantumKitHub/TensorKit.jl/pull/463))
+- Marked more error strings as lazy to reduce runtime overhead ([#478](https://github.com/QuantumKitHub/TensorKit.jl/pull/478))
 
 ## [0.17.0](https://github.com/QuantumKitHub/TensorKit.jl/compare/v0.16.5...v0.17.0) - 2026-06-03
 


### PR DESCRIPTION
## TensorKit.jl v0.17.1

A feature-and-performance patch release adding a matrix exponential (`exponential`/`exponential!`), broader Enzyme AD support, and several trivial-symmetry performance improvements.

### Highlights
- **Matrix exponential**: new `exponential` and `exponential!` for tensors (#465)
- **Enzyme AD**: forward and reverse rules for TensorOperations contractions, linear algebra, and VectorInterface, plus reverse rules for index manipulations (#436, #437, #440, #449, #451, #466)
- **Performance**: reduced overhead in the `TensorMap` constructor and trivial-symmetry code paths (#476, #479, #463, #478)
- **GPU**: consolidated GPU logic into a GPUArrays extension and dropped the explicit cuTENSOR dependency. Importing `cuTENSOR` is still recommended for best performance, as it enables the corresponding TensorOperations extension (#460, #455)
- **Docs**: added docstrings for `catdomain` and `catcodomain` (#485)

### Full Changelog
See [CHANGELOG](https://github.com/QuantumKitHub/TensorKit.jl/blob/main/docs/src/Changelog.md#0171---2026-07-13) for the complete list of changes.