### PR TITLE
Fix `--modules=` parsing in the benchmark entry point

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -5,12 +5,12 @@ const SUITE = TensorKitBenchmarks.SUITE
 # Populate benchmarks
 # Detect if user supplied extra arguments to load only specific modules
 # e.g. julia benchmarks.jl --modules=linalg,tensornetworks
-modules_pattern = r"(?:--modules=)(\w+)"
+modules_pattern = r"(?:--modules=)([\w,]+)"
 arg_id = findfirst(contains(modules_pattern), ARGS)
 if isnothing(arg_id)
     TensorKitBenchmarks.loadall!()
 else
-    modules = split(only(match(modules_pattern, ARGS[arg_id]).captures[1]), ",")
+    modules = split(match(modules_pattern, ARGS[arg_id]).captures[1], ",")
     for m in modules
         TensorKitBenchmarks.load!(m)
     end


### PR DESCRIPTION
Two bugs in `benchmark/benchmarks.jl`:

- the pattern captured `(\w+)`, which stops at the first comma, so `--modules=linalg,tensornetworks` silently loaded only `linalg`;
- `only(...)` was applied to the capture rather than the match, throwing for any module name longer than one character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)